### PR TITLE
[Refactor] 언어 현지화를 위해 문자열을 리소스 파일로 마이그레이션

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,2 @@
 <resources>
-    <string name="app_name">Minary</string>
 </resources>

--- a/presentation/src/main/java/kr/co/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/MainActivity.kt
@@ -8,10 +8,12 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kr.co.presentation.ui.extension.getString
 import kr.co.presentation.ui.navigation.host.RootNaveGraph
 import kr.co.presentation.ui.navigation.route.AuthGraph
 import kr.co.presentation.ui.navigation.route.MainGraph
@@ -40,12 +42,12 @@ class MainActivity : ComponentActivity() {
 
                 val navController = rememberNavController()
 
+                val context = LocalContext.current
+
                 mainActivityViewModel.collectSideEffect { sideEffect ->
                     when (sideEffect) {
                         is MainActivitySideEffect.ShowMsg -> scope.launch {
-                            snackbarHostState.showSnackbar(
-                                sideEffect.msg
-                            )
+                            snackbarHostState.showSnackbar(context.getString(sideEffect.uiText))
                         }
                     }
                 }

--- a/presentation/src/main/java/kr/co/presentation/ui/extension/ResourceExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/extension/ResourceExtensions.kt
@@ -1,0 +1,40 @@
+package kr.co.presentation.ui.extension
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import kr.co.presentation.ui.model.UiText
+
+
+/**
+ * 문자열 배열 리소스를 Composable로 가져오기 위한 확장 함수
+ *
+ * @param resId 문자열 배열 리소스 ID
+ * @return 리소스에 해당하는 [Array<String]
+ */
+@Composable
+fun stringArrayResource(@StringRes resId: Int): Array<String> {
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    return remember(resId, configuration) {
+        context.resources.getStringArray(resId)
+    }
+}
+
+/**
+ * [UiText] 객체를 [String] 문자열로 변환하는 [Context] 확장 함수
+ *
+ * ViewModel에서 전달된 UI 상태([UiText])를 문자열로 변환한다.
+ *
+ * @param uiText 변환할 [UiText] 객체 (DynamicString 또는 StringResource)
+ * @return 로컬라이징이나 인자가 적용된 최종 [String]
+ */
+fun Context.getString(uiText: UiText): String {
+    return when (uiText) {
+        is UiText.DynamicString -> uiText.value
+        is UiText.StringResource -> getString(uiText.resId, *uiText.args)
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/ui/model/UiText.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/model/UiText.kt
@@ -1,0 +1,41 @@
+package kr.co.presentation.ui.model
+
+import androidx.annotation.StringRes
+
+
+/**
+ * UI에 표시할 텍스트 데이터를 캡슐화하는 Sealed Interface
+ *
+ * 일반 문자열과 Android 리소스 문자열을 동일한 타입으로 ViewModel에서 UI 계층으로 전달하기 위해 사용
+ */
+sealed interface UiText {
+    /**
+     * 일반 [String] 타입의 문자열을 다룰 때 사용
+     * @property value 표시할 문자열 값
+     */
+    data class DynamicString(val value: String) : UiText
+
+    /**
+     * 안드로이드 문자열 리소스를 다룰 때 사용
+     * @property resId 문자열 리소스 ID
+     * @property args 리소스에 전달할 가변 인자
+     */
+    class StringResource(
+        @param:StringRes val resId: Int,
+        vararg val args: Any
+    ) : UiText {
+        // vararg 비교를 위한 equals와 hashCode
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is StringResource) return false
+            if (resId != other.resId) return false
+            return args.contentEquals(other.args)
+        }
+
+        override fun hashCode(): Int {
+            var result = resId
+            result = 31 * result + args.contentHashCode()
+            return result
+        }
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/ui/navigation/item/NavigationItem.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/navigation/item/NavigationItem.kt
@@ -3,4 +3,4 @@ package kr.co.presentation.ui.navigation.item
 import androidx.compose.ui.graphics.vector.ImageVector
 
 
-data class NavigationItem<T : Any>(val label: String, val route: T, val icon: ImageVector)
+data class NavigationItem<T : Any>(val labelResId: Int, val route: T, val icon: ImageVector)

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/auth/LoginScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/auth/LoginScreen.kt
@@ -28,11 +28,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
+import kr.co.presentation.R
+import kr.co.presentation.ui.extension.getString
 import kr.co.presentation.ui.theme.MinaryTheme
 import kr.co.presentation.viewmodel.auth.LoginSideEffect
 import kr.co.presentation.viewmodel.auth.LoginState
@@ -51,12 +55,14 @@ fun LoginScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
+    val context = LocalContext.current
+
     loginViewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is LoginSideEffect.NavigateToMainScreen -> onNavigateToMainScreen()
             is LoginSideEffect.NavigateToSignupScreen -> onNavigateToSignupScreen()
             is LoginSideEffect.ShowMsg -> scope.launch {
-                snackbarHostState.showSnackbar(sideEffect.msg)
+                snackbarHostState.showSnackbar(context.getString(sideEffect.uiText))
             }
         }
     }
@@ -119,7 +125,7 @@ private fun LoginScreen(
             ) {
                 Text(
                     modifier = Modifier.padding(top = 36.dp),
-                    text = "Log in",
+                    text = stringResource(R.string.login),
                     style = MaterialTheme.typography.headlineMedium
                 )
 
@@ -128,14 +134,14 @@ private fun LoginScreen(
                 // Id
                 Text(
                     modifier = Modifier.padding(top = 16.dp),
-                    text = "Id",
+                    text = stringResource(R.string.id),
                     style = MaterialTheme.typography.labelLarge
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
                     value = id,
                     onValueChange = onIdChanged,
-                    label = { Text("User Id") }
+                    label = { Text(stringResource(R.string.user_id)) }
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -143,14 +149,14 @@ private fun LoginScreen(
                 // Password
                 Text(
                     modifier = Modifier.padding(top = 16.dp),
-                    text = "Password",
+                    text = stringResource(R.string.password),
                     style = MaterialTheme.typography.labelLarge
                 )
                 OutlinedTextField(
                     modifier = Modifier.fillMaxWidth(),
                     value = password,
                     onValueChange = onPasswordChanged,
-                    label = { Text("User Password") },
+                    label = { Text(stringResource(R.string.user_password)) },
                     visualTransformation = PasswordVisualTransformation()
                 )
 
@@ -172,7 +178,7 @@ private fun LoginScreen(
                         ),
                         onClick = login
                     ) {
-                        Text(text = "Login")
+                        Text(text = stringResource(R.string.btn_login))
                     }
 
                     Spacer(modifier = Modifier.weight(1f))
@@ -183,8 +189,12 @@ private fun LoginScreen(
                             .padding(bottom = 24.dp)
                             .clickable(onClick = onNavigateToSignupScreen)
                     ) {
-                        Text(text = "Don't have an account?")
-                        Text(text = " Sign up ", color = MaterialTheme.colorScheme.primary)
+                        Text(text = stringResource(R.string.do_not_have_an_account))
+                        Text(
+                            text = stringResource(R.string.sign_up),
+                            color = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier.padding(start = 4.dp)
+                        )
                     }
                 }
             }
@@ -192,7 +202,7 @@ private fun LoginScreen(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, locale = "ko")
 @Composable
 private fun LoginScreenPreview() {
     MinaryTheme {

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/auth/SignUpScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/auth/SignUpScreen.kt
@@ -22,11 +22,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
+import kr.co.presentation.R
+import kr.co.presentation.ui.extension.getString
 import kr.co.presentation.ui.theme.MinaryTheme
 import kr.co.presentation.viewmodel.auth.SignUpSideEffect
 import kr.co.presentation.viewmodel.auth.SignUpState
@@ -44,11 +48,13 @@ fun SignUpScreen(
     val state: SignUpState by signupViewModel.collectAsState()
     val scope = rememberCoroutineScope()
 
+    val context = LocalContext.current
+
     signupViewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is SignUpSideEffect.NavigateToLoginScreen -> onNavigateToLoginScreen()
             is SignUpSideEffect.ShowMsg -> scope.launch {
-                snackbarHostState.showSnackbar(sideEffect.msg)
+                snackbarHostState.showSnackbar(context.getString(sideEffect.uiText))
             }
         }
     }
@@ -106,61 +112,61 @@ private fun SignUpScreen(
         ) {
             Text(
                 modifier = Modifier.padding(top = 36.dp),
-                text = "Create an account",
+                text = stringResource(R.string.create_an_account),
                 style = MaterialTheme.typography.headlineMedium
             )
 
             // Email
             Text(
                 modifier = Modifier.padding(top = 16.dp),
-                text = "Email",
+                text = stringResource(R.string.email),
                 style = MaterialTheme.typography.labelLarge
             )
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = email,
                 onValueChange = onEmailChanged,
-                label = { Text("User Email") },
+                label = { Text(stringResource(R.string.user_email)) },
             )
 
             // User Name
             Text(
                 modifier = Modifier.padding(top = 16.dp),
-                text = "Name",
+                text = stringResource(R.string.name),
                 style = MaterialTheme.typography.labelLarge
             )
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = userName,
                 onValueChange = onUserNameChanged,
-                label = { Text("User Name") }
+                label = { Text(stringResource(R.string.user_name)) }
             )
 
             // Password
             Text(
                 modifier = Modifier.padding(top = 16.dp),
-                text = "Password",
+                text = stringResource(R.string.password),
                 style = MaterialTheme.typography.labelLarge
             )
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = password,
                 onValueChange = onPasswordChanged,
-                label = { Text("User Password") },
+                label = { Text(stringResource(R.string.user_password)) },
                 visualTransformation = PasswordVisualTransformation()
             )
 
             // Confirm Password
             Text(
                 modifier = Modifier.padding(top = 16.dp),
-                text = "Confirm password",
+                text = stringResource(R.string.confirm_password),
                 style = MaterialTheme.typography.labelLarge
             )
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
                 value = confirmPassword,
                 onValueChange = onConfirmPasswordChanged,
-                label = { Text("User Confirm Password") },
+                label = { Text(stringResource(R.string.user_confirm_password)) },
                 visualTransformation = PasswordVisualTransformation()
             )
 
@@ -177,7 +183,7 @@ private fun SignUpScreen(
                 onClick = signUp
             ) {
                 Text(
-                    text = "Sign up",
+                    text = stringResource(R.string.sign_up),
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onPrimary
                 )
@@ -186,7 +192,7 @@ private fun SignUpScreen(
     }
 }
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, locale = "ko")
 @Composable
 private fun SignUpScreenPreview() {
     MinaryTheme {

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/MonthlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/MonthlyCalendarScreen.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -43,6 +42,7 @@ import kr.co.presentation.R
 import kr.co.presentation.ui.component.calendar.CalendarMonth
 import kr.co.presentation.ui.component.calendar.day.CalendarDay
 import kr.co.presentation.ui.component.calendar.day.OtherMonthDay
+import kr.co.presentation.ui.extension.stringArrayResource
 import kr.co.presentation.ui.navigation.route.Diary
 import kr.co.presentation.ui.preview.CalendarPreviewData
 import kr.co.presentation.ui.theme.MinaryTheme
@@ -192,18 +192,15 @@ fun TopBar(
                 }
         )
 
-        val context = LocalContext.current
-        val months = remember(context.resources.configuration) {
-            context.resources.getStringArray(R.array.months)
-        }
-        val monthStr = months[month - 1]
+        val months = stringArrayResource(R.array.months)
+        val monthText = months[month - 1]
 
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.Absolute.SpaceBetween,
         ) {
             Text(
-                text = monthStr,
+                text = monthText,
                 modifier = Modifier.padding(16.dp)
             )
 
@@ -219,10 +216,7 @@ fun TopBar(
 
 @Composable
 fun Weekday() {
-    val context = LocalContext.current
-    val weekday = remember(context.resources.configuration) {
-        context.resources.getStringArray(R.array.weekdays)
-    }
+    val weekday = stringArrayResource(R.array.weekdays)
 
     Row(
         modifier = Modifier

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/main/MainScreen.kt
@@ -20,11 +20,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kr.co.presentation.R
 import kr.co.presentation.ui.navigation.extensions.navigateIfNotCurrent
 import kr.co.presentation.ui.navigation.host.MainNavHost
 import kr.co.presentation.ui.navigation.item.NavigationItem
@@ -46,10 +48,10 @@ fun MainScreen(
 
     val navigationItems = remember {
         listOf(
-            NavigationItem("calendar", CalendarGraph, Icons.Filled.DateRange),
-            NavigationItem("dashboard", DashBoardGraph, Icons.Filled.Star),
-            NavigationItem("store", StoreGraph, Icons.Filled.ShoppingCart),
-            NavigationItem("setting", SettingGraph, Icons.Filled.Settings),
+            NavigationItem(R.string.calendar, CalendarGraph, Icons.Filled.DateRange),
+            NavigationItem(R.string.dashboard, DashBoardGraph, Icons.Filled.Star),
+            NavigationItem(R.string.store, StoreGraph, Icons.Filled.ShoppingCart),
+            NavigationItem(R.string.setting, SettingGraph, Icons.Filled.Settings),
         )
     }
 
@@ -62,8 +64,8 @@ fun MainScreen(
                     val currentDestination = navBackStackEntry?.destination
 
                     NavigationBarItem(
-                        icon = { Icon(item.icon, item.label) },
-                        label = { Text(item.label) },
+                        icon = { Icon(item.icon, stringResource(item.labelResId)) },
+                        label = { Text(stringResource(item.labelResId)) },
                         selected = (
                                 currentDestination?.hierarchy?.any {
                                     it.hasRoute(item.route::class)
@@ -89,12 +91,15 @@ fun MainScreen(
 @Composable
 private fun TopBar() {
     TopAppBar(
-        title = { Text("Minary") },
+        title = { Text(stringResource(R.string.app_name)) },
         actions = {
             IconButton(
                 onClick = {}
             ) {
-                Icon(Icons.Filled.Search, contentDescription = "Search")
+                Icon(
+                    Icons.Filled.Search,
+                    contentDescription = stringResource(R.string.search)
+                )
             }
         }
     )

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/auth/LoginViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/auth/LoginViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
 import kr.co.domain.usecase.LoginUseCase
+import kr.co.presentation.R
+import kr.co.presentation.ui.model.UiText
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -17,7 +19,7 @@ import javax.inject.Inject
 @Immutable
 data class LoginState(
     val isLoggingIn: Boolean = false,
-    val loginError: String = "Unknown error",
+    val loginError: UiText? = null,
     val id: String = "",
     val password: String = ""
 )
@@ -26,7 +28,7 @@ data class LoginState(
 sealed class LoginSideEffect {
     object NavigateToMainScreen : LoginSideEffect()
     object NavigateToSignupScreen : LoginSideEffect()
-    data class ShowMsg(val msg: String) : LoginSideEffect() // 오류 메시지 표시
+    data class ShowMsg(val uiText: UiText) : LoginSideEffect() // 오류 메시지 표시
 }
 
 @HiltViewModel
@@ -54,40 +56,54 @@ class LoginViewModel @Inject constructor(
 
     fun login() = intent {
         if (state.id.isNullOrBlank()) {
-            postSideEffect(LoginSideEffect.ShowMsg("Id is empty"))
+            postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.id_is_empty)))
             return@intent
         }
 
         if (state.password.isNullOrBlank()) {
-            postSideEffect(LoginSideEffect.ShowMsg("Password is empty"))
+            postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
             return@intent
         }
 
         reduce {
             // 로그인 시도 중, 오류 메시지 초기화
-            state.copy(isLoggingIn = true, loginError = "Unknown error")
+            state.copy(
+                isLoggingIn = true,
+                loginError = UiText.StringResource(R.string.unknown_error)
+            )
         }
 
         val login = loginUseCase(state.id, state.password)
         login.onSuccess {
             reduce {
-                state.copy(isLoggingIn = false, loginError = "Unknown error")
+                state.copy(
+                    isLoggingIn = false,
+                    loginError = UiText.StringResource(R.string.unknown_error)
+                )
             }
 
             postSideEffect(LoginSideEffect.NavigateToMainScreen)
         }.onFailure { error ->
             reduce {
                 // 로그인 실패, 오류 메시지 업데이트
-                state.copy(isLoggingIn = false, loginError = "Login failed")
+                state.copy(
+                    isLoggingIn = false,
+                    loginError = UiText.StringResource(R.string.login_failed)
+                )
             }
 
             when (error) {
                 is AuthException.SignInUserIsNullException -> {
-                    postSideEffect(LoginSideEffect.ShowMsg("Login failed"))
+                    postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.login_failed)))
                 }
 
                 else -> {
-                    postSideEffect(LoginSideEffect.ShowMsg(error.message.toString()))
+                    val uiText = error.message
+                        .takeIf { !it.isNullOrBlank() }
+                        ?.let { UiText.DynamicString(it) }
+                        ?: UiText.StringResource(R.string.unknown_error)
+
+                    postSideEffect(LoginSideEffect.ShowMsg(uiText))
                 }
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/auth/SignUpViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/auth/SignUpViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
 import kr.co.domain.usecase.SignUpUseCase
+import kr.co.presentation.R
+import kr.co.presentation.ui.model.UiText
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -25,7 +27,7 @@ data class SignUpState(
 sealed class SignUpSideEffect {
     object NavigateToLoginScreen : SignUpSideEffect()
 
-    data class ShowMsg(val msg: String) : SignUpSideEffect()
+    data class ShowMsg(val uiText: UiText) : SignUpSideEffect()
 }
 
 @HiltViewModel
@@ -53,27 +55,27 @@ class SignUpViewModel @Inject constructor(
 
     fun signUp() = intent {
         if (state.email.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg("Email is empty"))
+            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.email_is_empty)))
             return@intent
         }
 
         if (state.userName.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg("Name is empty"))
+            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.name_is_empty)))
             return@intent
         }
 
         if (state.password.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg("Password is empty"))
+            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
             return@intent
         }
 
         if (state.confirmPassword.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg("Confirm password is empty"))
+            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.confirm_password_is_empty)))
             return@intent
         }
 
         if (state.password != state.confirmPassword) {
-            postSideEffect(SignUpSideEffect.ShowMsg("Password does not match"))
+            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_not_match)))
             return@intent
         }
 
@@ -83,11 +85,16 @@ class SignUpViewModel @Inject constructor(
         }.onFailure { error ->
             when (error) {
                 is AuthException.CreateUserIsNullException -> {
-                    postSideEffect(SignUpSideEffect.ShowMsg("Create account failed"))
+                    postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.account_creation_failed)))
                 }
 
                 else -> {
-                    postSideEffect(SignUpSideEffect.ShowMsg(error.message.toString()))
+                    val uiText = error.message
+                        .takeIf { !it.isNullOrBlank()
+                        }?.let { UiText.DynamicString(it)
+                        }?: UiText.StringResource(R.string.unknown_error)
+
+                    postSideEffect(SignUpSideEffect.ShowMsg(uiText))
                 }
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainActivityViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainActivityViewModel.kt
@@ -6,6 +6,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
 import kr.co.domain.model.auth.User
 import kr.co.domain.usecase.IsUserLoggedInUseCase
+import kr.co.presentation.R
+import kr.co.presentation.ui.model.UiText
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -28,7 +30,7 @@ data class MainActivityState(
 
 @Immutable
 sealed class MainActivitySideEffect {
-    data class ShowMsg(val msg: String) : MainActivitySideEffect() // 오류 메시지 표시
+    data class ShowMsg(val uiText: UiText) : MainActivitySideEffect() // 오류 메시지 표시
 }
 
 @HiltViewModel
@@ -55,10 +57,15 @@ class MainActivityViewModel @Inject constructor(
 
             when(error) {
                 is AuthException.CurrentUserIsNullException -> {
-                    postSideEffect(MainActivitySideEffect.ShowMsg("Current user is null"))
+                    postSideEffect(MainActivitySideEffect.ShowMsg(UiText.StringResource(R.string.current_user_is_null)))
                 }
                 else -> {
-                    postSideEffect(MainActivitySideEffect.ShowMsg(error.message.toString()))
+                    val uiText = error.message
+                        .takeIf { !it.isNullOrBlank() }
+                        ?.let { UiText.DynamicString(it) }
+                        ?: UiText.StringResource(R.string.unknown_error)
+
+                    postSideEffect(MainActivitySideEffect.ShowMsg(uiText))
                 }
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainViewModel.kt
@@ -2,6 +2,7 @@ package kr.co.presentation.viewmodel.main
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kr.co.presentation.ui.model.UiText
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
 import javax.annotation.concurrent.Immutable
@@ -14,7 +15,7 @@ data class MainState(
 )
 
 sealed class MainSideEffect {
-    data class ShowMsg(val msg: String) : MainSideEffect()
+    data class ShowMsg(val uiText: UiText) : MainSideEffect()
 }
 
 @HiltViewModel

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name">Minary</string>
     <string-array name="weekdays">
         <item>일</item>
         <item>월</item>
@@ -27,6 +28,35 @@
     <string name="month_title">%1$d월</string>
     <string name="you_cannot_select_a_date_after_today">오늘 이후에는 날짜를 선택할 수 없습니다</string>
     <string name="welcome">환영합니다.</string>
-    <string name="your_mind_diary">당신의 마음속 다이어리를 작성해보세요.</string>
+    <string name="your_mind_diary">당신의 마음속 다이어리를 작성해보세요</string>
     <string name="login">로그인</string>
+    <string name="id">아이디</string>
+    <string name="user_id">사용자 아이디</string>
+    <string name="password">비밀번호</string>
+    <string name="user_password">사용자 비밀번호</string>
+    <string name="btn_login">로그인</string>
+    <string name="do_not_have_an_account">계정이 없으신가요?</string>
+    <string name="sign_up">회원가입</string>
+    <string name="create_an_account">계정 만들기</string>
+    <string name="email">이메일</string>
+    <string name="user_email">사용자 이메일</string>
+    <string name="name">이름</string>
+    <string name="user_name">사용자 이름</string>
+    <string name="confirm_password">비밀번호 확인</string>
+    <string name="user_confirm_password">사용자 비밀번호 확인</string>
+    <string name="search">검색</string>
+    <string name="calendar">달력</string>
+    <string name="dashboard">대시보드</string>
+    <string name="store">상점</string>
+    <string name="setting">환경설정</string>
+    <string name="id_is_empty">아이디가 비어 있습니다</string>
+    <string name="password_is_empty">패스워드가 비어 있습니다</string>
+    <string name="unknown_error">알 수 없는 오류</string>
+    <string name="login_failed">로그인 실패</string>
+    <string name="email_is_empty">이메일이 비어 있습니다</string>
+    <string name="name_is_empty">이름이 비어 있습니다</string>
+    <string name="confirm_password_is_empty">비밀번호 확인칸이 비어 있습니다</string>
+    <string name="password_not_match">비밀번호가 일치하지 않습니다</string>
+    <string name="account_creation_failed">계정 생성에 실패했습니다</string>
+    <string name="current_user_is_null">없는 사용자입니다</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name">Minary</string>
     <string-array name="weekdays">
         <item>Sun</item>
         <item>Mon</item>
@@ -27,6 +28,35 @@
     <string name="month_title">%1$d</string>
     <string name="you_cannot_select_a_date_after_today">You cannot select a date after today</string>
     <string name="welcome">Welcome</string>
-    <string name="your_mind_diary">\"Your mind diary\"</string>
-    <string name="login">\"Login\"</string>
+    <string name="your_mind_diary">Your mind diary</string>
+    <string name="login">Login</string>
+    <string name="id">Id</string>
+    <string name="user_id">User Id</string>
+    <string name="password">Password</string>
+    <string name="user_password">User Password</string>
+    <string name="btn_login">Login</string>
+    <string name="do_not_have_an_account">Don\'t have an account?</string>
+    <string name="sign_up">Sign up</string>
+    <string name="create_an_account">Create an account</string>
+    <string name="email">Email</string>
+    <string name="user_email">User Email</string>
+    <string name="name">Name</string>
+    <string name="user_name">User Name</string>
+    <string name="confirm_password">Confirm password</string>
+    <string name="user_confirm_password">User Confirm Password</string>
+    <string name="search">Search</string>
+    <string name="calendar">calendar</string>
+    <string name="dashboard">dashboard</string>
+    <string name="store">store</string>
+    <string name="setting">setting</string>
+    <string name="id_is_empty">Id is empty</string>
+    <string name="password_is_empty">Password is empty</string>
+    <string name="unknown_error">Unknown error</string>
+    <string name="login_failed">Login failed</string>
+    <string name="email_is_empty">Email is empty</string>
+    <string name="name_is_empty">Name is empty</string>
+    <string name="confirm_password_is_empty">Confirm password is empty</string>
+    <string name="password_not_match">Password does not match</string>
+    <string name="account_creation_failed">Account creation failed</string>
+    <string name="current_user_is_null">Current user is null</string>
 </resources>


### PR DESCRIPTION
## 목적
- Refactor : 언어 현지화를 위해 문자열을 리소스 파일로 마이그레이션

## 관련 이슈
- Closes #3 

## 변경 사항
- 하드코딩된 문자열을 string.xml 파일로 마이그레이션
- ViewModel에서 관리하는 문자열도 리소스 ID로 관리될 수 있도록 변경
- ViewModel에서 일반 문자열과 리소스 ID를 동일한 타입으로 UI 계층에 전달하기 위해 UiText 클래스 생성
- ViewModel에서 전달된 UiText 클래스를 문자열로 변환하기 위해 확장 함수 생성(ResourceExtensions.kt)