### PR TITLE
bug: Resource Annotation Error 처리

### DIFF
--- a/presentation/src/main/java/kr/co/presentation/ui/extension/ResourceExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/extension/ResourceExtensions.kt
@@ -1,7 +1,7 @@
 package kr.co.presentation.ui.extension
 
 import android.content.Context
-import androidx.annotation.StringRes
+import androidx.annotation.ArrayRes
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalConfiguration
@@ -16,7 +16,7 @@ import kr.co.presentation.ui.model.UiText
  * @return 리소스에 해당하는 [Array<String]
  */
 @Composable
-fun stringArrayResource(@StringRes resId: Int): Array<String> {
+fun stringArrayResource(@ArrayRes resId: Int): Array<String> {
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
     return remember(resId, configuration) {


### PR DESCRIPTION
## 설명
- [Bug] array resource id를 받는 지점에 string resource id를 암시하는 annotation이 선언되어 있기에 올바르게 선언.

## 관련 이슈
- Closes #19