### PR TITLE
feat: 일기 작성 및 상세 화면 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.kotlin.dsl.implementation
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -9,6 +7,8 @@ plugins {
     alias(libs.plugins.hilt)
     // firebase
     alias(libs.plugins.firebase)
+    // secrets
+    alias(libs.plugins.secrets)
 }
 
 android {
@@ -23,6 +23,10 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        buildConfig = true
     }
 
     buildTypes {
@@ -59,9 +63,11 @@ dependencies {
     // hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
+    implementation(libs.hilt.work)
 
     // firebase
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics.ktx)
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,19 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        tools:targetApi="35"/>
+        tools:targetApi="35">
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
+    </application>
 
 </manifest>

--- a/app/src/main/java/kr/co/minary/MinaryApplication.kt
+++ b/app/src/main/java/kr/co/minary/MinaryApplication.kt
@@ -1,12 +1,23 @@
 package kr.co.minary
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 
 @HiltAndroidApp
-class MinaryApplication : Application() {
+class MinaryApplication : Application(), Configuration.Provider {
+
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/kr/co/minary/di/AppModule.kt
+++ b/app/src/main/java/kr/co/minary/di/AppModule.kt
@@ -2,14 +2,13 @@ package kr.co.minary.di
 
 import android.app.Application
 import android.content.Context
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.ktx.Firebase
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kr.co.data.di.GeminiApiKey
+import kr.co.minary.BuildConfig
 import javax.inject.Singleton
 
 
@@ -20,4 +19,14 @@ abstract class AppModule {
     @Singleton
     @Binds
     abstract fun bindContext(application: Application): Context
+
+    companion object {
+
+        @Provides
+        @Singleton
+        @GeminiApiKey
+        fun provideGeminiApiKey(): String {
+            return BuildConfig.GEMINI_API_KEY
+        }
+    }
 }

--- a/app/src/main/java/kr/co/minary/di/FirebaseModule.kt
+++ b/app/src/main/java/kr/co/minary/di/FirebaseModule.kt
@@ -2,6 +2,8 @@ package kr.co.minary.di
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import dagger.Module
 import dagger.Provides
@@ -17,4 +19,9 @@ object FirebaseModule {
     @Singleton
     @Provides
     fun provideFirebaseAuth(): FirebaseAuth = Firebase.auth
+
+    @Singleton
+    @Provides
+    fun provideFirebaseFirestore(): FirebaseFirestore = Firebase.firestore
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,6 @@ plugins {
     // serialization
     alias(libs.plugins.serialization) apply false
     alias(libs.plugins.firebase) apply false
+    // secrets
+    alias(libs.plugins.secrets) apply false
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -49,6 +49,8 @@ dependencies {
     // hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
+    implementation(libs.hilt.work)
+    ksp(libs.hilt.compiler)
 
     // serialization
     implementation(libs.kotlinx.serialization.json)
@@ -60,6 +62,7 @@ dependencies {
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.analytics.ktx)
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.firestore.ktx)
 
     // paging
     implementation(libs.androidx.paging.runtime)
@@ -67,6 +70,18 @@ dependencies {
 
     // coroutines
     implementation(libs.kotlinx.coroutines.android)
+
+    // room
+    implementation(libs.androidx.room.runtime)
+    ksp(libs.androidx.room.compiler)
+    implementation(libs.androidx.room.ktx)
+    testImplementation(libs.androidx.room.testing)
+
+    // generative ai
+    implementation(libs.generative.ai)
+
+    // work
+    implementation(libs.androidx.work.runtime.ktx)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/data/src/main/java/kr/co/data/converter/BooleanConverters.kt
+++ b/data/src/main/java/kr/co/data/converter/BooleanConverters.kt
@@ -1,0 +1,17 @@
+package kr.co.data.converter
+
+import androidx.room.TypeConverter
+
+
+object BooleanConverters {
+
+    @TypeConverter
+    fun fromBoolean(value: Boolean?): Int? {
+        return if (value == null) null else if (value) 1 else 0
+    }
+
+    @TypeConverter
+    fun toBoolean(value: Int?): Boolean? {
+        return if (value == null) null else value == 1
+    }
+}

--- a/data/src/main/java/kr/co/data/converter/DateConverters.kt
+++ b/data/src/main/java/kr/co/data/converter/DateConverters.kt
@@ -1,0 +1,20 @@
+package kr.co.data.converter
+
+import androidx.room.TypeConverter
+import kr.co.domain.extention.dateToString
+import kr.co.domain.extention.toLocalDate
+import java.time.LocalDate
+
+
+object DateConverters {
+
+    @TypeConverter
+    fun fromString(value: String?): LocalDate? {
+        return value?.toLocalDate()
+    }
+
+    @TypeConverter
+    fun dateToString(date: LocalDate?): String? {
+        return date?.dateToString()
+    }
+}

--- a/data/src/main/java/kr/co/data/di/CoroutineScopesModule.kt
+++ b/data/src/main/java/kr/co/data/di/CoroutineScopesModule.kt
@@ -1,0 +1,56 @@
+package kr.co.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CoroutineScopesModule {
+
+    /**
+     * Dispatchers.Default를 사용하는 코루틴 스코프를 제공합니다.
+     * 주로 CPU-bound 작업이나 비동기 작업에 사용됩니다.
+     */
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun providesCoroutineScope(
+        @DefaultDispatcher defaultDispatcher: CoroutineDispatcher
+    ): CoroutineScope {
+        // SupervisorJob: 자식 코루틴 중 하나가 실패해도 다른 자식이나 부모가 취소되지 않음
+        return CoroutineScope(SupervisorJob() + defaultDispatcher)
+    }
+
+    /**
+     * IO Dispatcher를 사용하는 코루틴 스코프를 제공합니다.
+     * 주로 파일 입출력, 네트워크 통신 등 블로킹이 발생할 수 있는 I/O 작업에 사용됩니다.
+     */
+    @Provides
+    @Singleton
+    @IoScope
+    fun providesIoScope(
+        @IoDispatcher ioDispatcher: CoroutineDispatcher
+    ): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + ioDispatcher)
+    }
+
+    /**
+     * Main Dispatcher를 사용하는 코루틴 스코프를 제공합니다.
+     * 주로 UI와 직접 상호작용하는 작업에 사용됩니다.
+     */
+    @Provides
+    @Singleton
+    @MainScope
+    fun providesMainScope(
+        @MainDispatcher mainDispatcher: CoroutineDispatcher
+    ): CoroutineScope {
+        return CoroutineScope(SupervisorJob() + mainDispatcher)
+    }
+}

--- a/data/src/main/java/kr/co/data/di/DataModule.kt
+++ b/data/src/main/java/kr/co/data/di/DataModule.kt
@@ -1,15 +1,26 @@
 package kr.co.data.di
 
+import android.content.Context
+import androidx.room.Room
+import androidx.work.WorkManager
+import com.google.ai.client.generativeai.GenerativeModel
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kr.co.data.local.AppDatabase
+import kr.co.data.local.dao.DiaryDAO
 import kr.co.data.repository.AuthRepositoryImpl
-import kr.co.data.repository.AuthTokenRepositoryImpl
 import kr.co.data.repository.CalendarRepositoryImpl
+import kr.co.data.repository.DiaryRepositoryImpl
+import kr.co.data.source.EmotionAnalysisAiDataSource
 import kr.co.domain.repository.AuthRepository
-import kr.co.domain.repository.AuthTokenRepository
 import kr.co.domain.repository.CalendarRepository
+import kr.co.domain.repository.DiaryRepository
+import javax.inject.Named
+import javax.inject.Qualifier
 import javax.inject.Singleton
 
 
@@ -17,6 +28,46 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 abstract class DataModule {
 
+    companion object {
+        @Provides
+        @Singleton
+        fun provideAppDatabase(@ApplicationContext context: Context): AppDatabase {
+            return Room.databaseBuilder(
+                context,
+                AppDatabase::class.java,
+                "minary_db"
+            ).build()
+        }
+
+        @Provides
+        @Singleton
+        fun provideDiaryDao(appDatabase: AppDatabase): DiaryDAO {
+            return appDatabase.diaryDao()
+        }
+
+        @Provides
+        @Singleton
+        fun provideGenerativeModel(@GeminiApiKey apiKey: String): GenerativeModel {
+            return GenerativeModel(
+                modelName = "gemini-2.5-flash-lite",
+                apiKey = apiKey,
+            )
+        }
+
+        @Provides
+        @Singleton
+        fun provideEmotionAnalysisAiDataSource(generativeModel: GenerativeModel): EmotionAnalysisAiDataSource {
+            return EmotionAnalysisAiDataSource(generativeModel)
+        }
+
+        @Provides
+        @Singleton
+        fun provideWorkManager(
+            @ApplicationContext context: Context
+        ): WorkManager {
+            return WorkManager.getInstance(context)
+        }
+    }
     /* FirebaseAuth 이전에 사용하던 의존성 주입
     @Binds
     abstract fun bindAuthTokenRepository(impl: AuthTokenRepositoryImpl): AuthTokenRepository*/
@@ -28,4 +79,8 @@ abstract class DataModule {
     @Binds
     @Singleton
     abstract fun bindCalendarRepository(impl: CalendarRepositoryImpl): CalendarRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindDiaryRepository(impl: DiaryRepositoryImpl): DiaryRepository
 }

--- a/data/src/main/java/kr/co/data/di/DispatchersModule.kt
+++ b/data/src/main/java/kr/co/data/di/DispatchersModule.kt
@@ -1,0 +1,26 @@
+package kr.co.data.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+
+    @Provides
+    @DefaultDispatcher
+    fun providesDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @IoDispatcher
+    fun providesIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @MainDispatcher
+    fun providesMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+}

--- a/data/src/main/java/kr/co/data/di/Qualifiers.kt
+++ b/data/src/main/java/kr/co/data/di/Qualifiers.kt
@@ -1,0 +1,31 @@
+package kr.co.data.di
+
+import javax.inject.Qualifier
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class GeminiApiKey
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class DefaultDispatcher
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class IoDispatcher
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class MainDispatcher
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class ApplicationScope
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class IoScope
+
+@Retention(AnnotationRetention.BINARY)
+@Qualifier
+annotation class MainScope

--- a/data/src/main/java/kr/co/data/local/AppDatabase.kt
+++ b/data/src/main/java/kr/co/data/local/AppDatabase.kt
@@ -1,0 +1,16 @@
+package kr.co.data.local
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import kr.co.data.converter.BooleanConverters
+import kr.co.data.converter.DateConverters
+import kr.co.data.local.dao.DiaryDAO
+import kr.co.data.model.diary.DiaryEntity
+
+
+@Database(entities = [DiaryEntity::class], version = 1)
+@TypeConverters(DateConverters::class, BooleanConverters::class)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun diaryDao(): DiaryDAO
+}

--- a/data/src/main/java/kr/co/data/local/DiaryTable.kt
+++ b/data/src/main/java/kr/co/data/local/DiaryTable.kt
@@ -1,0 +1,15 @@
+package kr.co.data.local
+
+
+object DiaryTable {
+    const val TABLE_NAME = "diary"
+
+    const val COLUMN_ID = "id"
+    const val COLUMN_DATE = "date"
+    const val COLUMN_TITLE = "title"
+    const val COLUMN_CONTENT = "content"
+    const val COLUMN_EMOTION_NAME = "emotionName"
+    const val COLUMN_TIMESTAMP = "timestamp"
+    const val COLUMN_IS_SYNCED = "isSynced"
+    const val COLUMN_IS_DELETED = "isDeleted"
+}

--- a/data/src/main/java/kr/co/data/local/dao/DiaryDAO.kt
+++ b/data/src/main/java/kr/co/data/local/dao/DiaryDAO.kt
@@ -1,0 +1,102 @@
+package kr.co.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+import kr.co.data.model.diary.DiaryEntity
+import java.time.LocalDate
+
+
+@Dao
+interface DiaryDAO {
+
+    /**
+     * 로컬 DB에 저장된 일기의 총 개수를 반환합니다.
+     * @return 일기 개수
+     */
+    @Query("SELECT COUNT(id) FROM diary")
+    suspend fun countDiaries(): Int
+
+    /**
+     * [date]에 해당하는 일기 중 삭제되지 않은 일기를 조회합니다.
+     *
+     * @return 데이터가 있으면 DiaryEntity, 없으면 null을 반환합니다.
+     */
+    @Query("SELECT * FROM diary WHERE date = :date AND isDeleted = 0")
+    suspend fun getDiaryByDate(date: LocalDate): DiaryEntity?
+
+    /**
+     * [startDate]와 [endDate] 사이의 삭제되지 않은 모든 일기를 Flow 형태로 조회합니다.
+     *
+     * @param startDate 시작 날짜
+     * @param endDate 종료 날짜
+     * @return diary 테이블의 데이터가 변경되면 Flow가 자동으로 새 목록을 방출합니다.
+     */
+    @Query("SELECT * FROM diary WHERE date BETWEEN :startDate AND :endDate AND isDeleted = 0")
+    fun getDiariesFlowByRange(startDate: LocalDate, endDate: LocalDate): Flow<List<DiaryEntity>>
+
+    /**
+     * 서버와 동기화되지 않은 모든 일기를 조회합니다.
+     *
+     * @return 동기화되지 않은 일기 목록. 없으면 null을 반환합니다.
+     */
+    @Query("SELECT * FROM diary WHERE isSynced = 0")
+    suspend fun getUnsyncedDiaries(): List<DiaryEntity>?
+
+    /**
+     * 주어진 [ids] 목록에 해당하는 모든 일기의 `isSynced` 상태를 한 번에 업데이트합니다.
+     *
+     * @param ids 업데이트할 일기 ID 목록
+     * @param isSynced 적용할 동기화 상태
+     * @return 업데이트된 행의 개수를 반환합니다.
+     */
+    @Query("UPDATE diary SET isSynced = :isSynced WHERE id IN (:ids)")
+    suspend fun updateSyncStatus(ids: List<Long>, isSynced: Boolean): Int
+
+    /**
+     * 주어진 [id]에 해당하는 일기를 삭제 상태([isDeleted])로 변경하고,
+     * 동기화가 필요하도록 `isSynced` 상태를 `false`로 설정합니다.
+     *
+     * @param id 업데이트할 일기 ID
+     * @param isDeleted 적용할 삭제 상태
+     * @return 업데이트된 행의 개수를 반환합니다.
+     */
+    @Query("UPDATE diary SET isDeleted = :isDeleted, isSynced = 0 WHERE id = :id")
+    suspend fun updateDeleteStatus(id: Long, isDeleted: Boolean): Int
+
+    /**
+     * [diaryEntity]를 데이터베이스에 삽입하거나, Primary Key가 이미 존재하면 업데이트합니다. (Upsert)
+     *
+     * @return 추가되거나 업데이트된 행의 ID를 반환합니다.
+     */
+    @Upsert
+    suspend fun upsertDiary(diaryEntity: DiaryEntity): Long
+
+    /**
+     * 주어진 [diaries] 목록을 데이터베이스에 삽입하거나, Primary Key가 이미 존재하면 업데이트합니다. (Upsert)
+     *
+     * @param diaries Upsert할 DiaryEntity 목록
+     * @return 추가되거나 업데이트된 행의 ID 목록을 반환합니다.
+     */
+    @Upsert
+    suspend fun upsertDiaries(diaries: List<DiaryEntity>): List<Long>
+
+    /**
+     * 주어진 [diaryEntity]와 일치하는 일기를 데이터베이스에서 삭제합니다.
+     *
+     * @return 삭제된 행의 개수를 반환합니다.
+     */
+    @Delete
+    suspend fun deleteDiary(diaryEntity: DiaryEntity): Int
+
+    /**
+     * 주어진 [ids] 목록과 일치하는 모든 일기를 데이터베이스에서 삭제합니다.
+     *
+     * @param ids 삭제할 일기 ID 목록
+     * @return 삭제된 행의 개수를 반환합니다.
+     */
+    @Query("DELETE FROM diary WHERE id IN (:ids)")
+    suspend fun deleteDiariesByIds(ids: List<Long>): Int
+}

--- a/data/src/main/java/kr/co/data/mapper/CalendarDataMapper.kt
+++ b/data/src/main/java/kr/co/data/mapper/CalendarDataMapper.kt
@@ -11,10 +11,11 @@ import kr.co.domain.model.calendar.day.DayData
 import kr.co.domain.model.calendar.day.InactiveDayData
 import kr.co.domain.model.calendar.yearmonth.MonthData
 import kr.co.domain.model.calendar.yearmonth.YearData
+import kr.co.domain.model.calendar.yearmonth.YearMonthData
 
 
 object CalendarDataMapper {
-    fun YearMonthDTO.toYearMonthData(): kr.co.domain.model.calendar.yearmonth.YearMonthData {
+    fun YearMonthDTO.toYearMonthData(): YearMonthData {
         return when (this) {
             is YearDTO -> this.toYearData()
             is MonthDTO -> this.toMonthData()
@@ -38,7 +39,6 @@ object CalendarDataMapper {
         return when (this) {
             is ActiveDayDTO -> ActiveDayData(
                 date = date,
-                icon = icon,
             )
 
             is InactiveDayDTO -> InactiveDayData(

--- a/data/src/main/java/kr/co/data/mapper/DiaryEntityMapper.kt
+++ b/data/src/main/java/kr/co/data/mapper/DiaryEntityMapper.kt
@@ -1,0 +1,53 @@
+package kr.co.data.mapper
+
+import kr.co.data.model.diary.DiaryEntity
+import kr.co.data.model.diary.FirestoreDiaryDto
+import kr.co.domain.extention.dateToString
+import kr.co.domain.extention.toLocalDate
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.model.emotion.Emotion
+
+
+object DiaryEntityMapper {
+    fun DiaryData.toDiaryEntity() = DiaryEntity(
+        id = id,
+        date = date,
+        title = title,
+        content = content,
+        emotionName = emotion.name,
+        timestamp = timestamp,
+        isSynced = isSynced,
+        isDeleted = isDeleted,
+    )
+
+    fun DiaryEntity.toDiaryData() = DiaryData(
+        id = id,
+        date = date,
+        title = title,
+        content = content,
+        emotion = Emotion.fromString(emotionName),
+        timestamp = timestamp,
+        isSynced = isSynced,
+        isDeleted = isDeleted,
+    )
+
+    fun FirestoreDiaryDto.toDiaryEntity() = DiaryEntity(
+        id = id,
+        date = date.toLocalDate(),
+        title = title,
+        content = content,
+        emotionName = emotionName,
+        timestamp = timestamp,
+        isSynced = true,
+        isDeleted = false,
+    )
+
+    fun DiaryEntity.toFirestoreDiaryDto() = FirestoreDiaryDto(
+        id = id,
+        date = date.dateToString(),
+        title = title,
+        content = content,
+        emotionName = emotionName,
+        timestamp = timestamp,
+    )
+}

--- a/data/src/main/java/kr/co/data/model/calendar/day/ActiveDayDTO.kt
+++ b/data/src/main/java/kr/co/data/model/calendar/day/ActiveDayDTO.kt
@@ -5,5 +5,4 @@ import java.time.LocalDate
 
 data class ActiveDayDTO(
     override val date: LocalDate = LocalDate.now(),
-    val icon: String = "",
 ) : DayDTO

--- a/data/src/main/java/kr/co/data/model/diary/DiaryEntity.kt
+++ b/data/src/main/java/kr/co/data/model/diary/DiaryEntity.kt
@@ -1,0 +1,34 @@
+package kr.co.data.model.diary
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import kr.co.data.local.DiaryTable.COLUMN_CONTENT
+import kr.co.data.local.DiaryTable.COLUMN_DATE
+import kr.co.data.local.DiaryTable.COLUMN_EMOTION_NAME
+import kr.co.data.local.DiaryTable.COLUMN_ID
+import kr.co.data.local.DiaryTable.COLUMN_IS_DELETED
+import kr.co.data.local.DiaryTable.COLUMN_IS_SYNCED
+import kr.co.data.local.DiaryTable.COLUMN_TIMESTAMP
+import kr.co.data.local.DiaryTable.COLUMN_TITLE
+import kr.co.data.local.DiaryTable.TABLE_NAME
+import java.time.LocalDate
+
+
+@Entity(
+    tableName = TABLE_NAME,
+    indices = [Index(value = [COLUMN_DATE], unique = true)])
+data class DiaryEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = COLUMN_ID) val id: Long = 0L,
+
+    @ColumnInfo(name = COLUMN_DATE) val date: LocalDate,
+    @ColumnInfo(name = COLUMN_TITLE) val title: String,
+    @ColumnInfo(name = COLUMN_CONTENT) val content: String,
+    @ColumnInfo(name = COLUMN_EMOTION_NAME) val emotionName: String,
+
+    @ColumnInfo(name = COLUMN_TIMESTAMP) val timestamp: Long,
+    @ColumnInfo(name = COLUMN_IS_SYNCED) val isSynced: Boolean,
+    @ColumnInfo(name = COLUMN_IS_DELETED) val isDeleted: Boolean,
+)

--- a/data/src/main/java/kr/co/data/model/diary/FirestoreDiaryDto.kt
+++ b/data/src/main/java/kr/co/data/model/diary/FirestoreDiaryDto.kt
@@ -1,0 +1,52 @@
+package kr.co.data.model.diary
+
+import androidx.annotation.Keep
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kr.co.data.local.DiaryTable.COLUMN_CONTENT
+import kr.co.data.local.DiaryTable.COLUMN_DATE
+import kr.co.data.local.DiaryTable.COLUMN_EMOTION_NAME
+import kr.co.data.local.DiaryTable.COLUMN_ID
+import kr.co.data.local.DiaryTable.COLUMN_TIMESTAMP
+import kr.co.data.local.DiaryTable.COLUMN_TITLE
+
+
+/**
+ * firestore에 저장할 DiaryDto
+ *
+ * firestore는 @SerialName를 직접 사용하지 않습니다.
+ * 다만 나중에 다른 REST API(Gson)의 DTO로 사용할 수 있도록 @SerialName을 사용합니다.
+ *
+ * @property id
+ * @property date
+ * @property title
+ * @property content
+ * @property emotionName
+ * @property timestamp
+ */
+@Keep
+@Serializable
+data class FirestoreDiaryDto(
+    @SerialName(COLUMN_ID)
+    val id: Long = 0L,
+
+    @SerialName(COLUMN_DATE)
+    val date: String = "",
+
+    @SerialName(COLUMN_TITLE)
+    val title: String = "",
+
+    @SerialName(COLUMN_CONTENT)
+    val content: String = "",
+
+    @SerialName(COLUMN_EMOTION_NAME)
+    val emotionName: String = "",
+
+    @SerialName(COLUMN_TIMESTAMP)
+    val timestamp: Long = 0L,
+) {
+    // firestore의 toObject()는 인자 없는 클래스의 기본 생성자 FirestoreDiaryDto()를 호출합니다.
+    // 1. data class로 써 모든 프로퍼티를 초기화 하여 인자 없는 기본 생성자를 자동 호출 가능하게 하거나
+    // 2. 또는 인자 없는 부생성자 선언하고, 기본 생성자를 명시적으로 초기화 할 수 있도록 해야합니다.
+    constructor() : this(0L, "", "", "", "", 0L)
+}

--- a/data/src/main/java/kr/co/data/remote/DiaryDownloadWorker.kt
+++ b/data/src/main/java/kr/co/data/remote/DiaryDownloadWorker.kt
@@ -1,0 +1,59 @@
+package kr.co.data.remote
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.tasks.await
+import kr.co.data.local.dao.DiaryDAO
+import kr.co.data.mapper.DiaryEntityMapper.toDiaryEntity
+import kr.co.data.model.diary.FirestoreDiaryDto
+import kr.co.data.remote.FirestorePaths.COLLECTION_DIARIES
+import kr.co.data.remote.FirestorePaths.COLLECTION_USERS
+
+
+@HiltWorker
+class DiaryDownloadWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val diaryDao: DiaryDAO,
+    private val firestore: FirebaseFirestore,
+    private val firebaseAuth: FirebaseAuth
+) : CoroutineWorker(appContext, workerParams) {
+
+    companion object {
+        const val WORK_DIARY_DOWNLOAD = "diary_sync_download"
+    }
+
+    override suspend fun doWork(): Result {
+        if (runAttemptCount > 5) Result.failure()
+        val userId = firebaseAuth.currentUser?.uid ?: return Result.failure()
+
+        try {
+            val diariesSnapshot =
+                firestore
+                    .collection(COLLECTION_USERS)
+                    .document(userId)
+                    .collection(COLLECTION_DIARIES)
+                    .get()
+                    .await()
+
+            val downloadDiaries = diariesSnapshot.documents.mapNotNull { diaryDocSnapshot ->
+                val firestoreDiaryDto = diaryDocSnapshot.toObject(FirestoreDiaryDto::class.java)!!
+                firestoreDiaryDto.toDiaryEntity().copy(isSynced = true, isDeleted = false)
+            }
+
+            if (downloadDiaries.isNotEmpty()) {
+                diaryDao.upsertDiaries(downloadDiaries)
+            }
+            return Result.success()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            return if (runAttemptCount > 2) Result.failure() else Result.retry()
+        }
+    }
+}

--- a/data/src/main/java/kr/co/data/remote/DiaryRemoteDataSource.kt
+++ b/data/src/main/java/kr/co/data/remote/DiaryRemoteDataSource.kt
@@ -1,0 +1,131 @@
+package kr.co.data.remote
+
+import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ListenerRegistration
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kr.co.data.di.IoScope
+import kr.co.data.local.dao.DiaryDAO
+import kr.co.data.mapper.DiaryEntityMapper.toDiaryEntity
+import kr.co.data.model.diary.FirestoreDiaryDto
+import kr.co.data.remote.DiaryDownloadWorker.Companion.WORK_DIARY_DOWNLOAD
+import kr.co.data.remote.DiarySyncWorker.Companion.WORK_DIARY_SYNC
+import kr.co.data.remote.FirestorePaths.COLLECTION_DIARIES
+import kr.co.data.remote.FirestorePaths.COLLECTION_USERS
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+
+class DiaryRemoteDataSource @Inject constructor(
+    private val workManager: WorkManager,
+    private val firestore: FirebaseFirestore,
+    private val auth: FirebaseAuth,
+    private val diaryDao: DiaryDAO,
+    @IoScope private val ioScope: CoroutineScope
+) {
+    companion object {
+        private val TAG: String = DiaryRemoteDataSource::class.java.simpleName
+    }
+
+    private var listenerRegistration: ListenerRegistration? = null
+
+    /**
+     * Firestore에 전체 일기 데이터 요청을 스케줄링
+     *
+     * 초기 로컬 DB 생성을 위해 Firestore의 모든 데이터를 가져오는 스케줄링
+     */
+    fun scheduleDiaryDownload() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val diaryDownloadWorker = OneTimeWorkRequestBuilder<DiaryDownloadWorker>()
+            .setConstraints(constraints)
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL, // 실패시 재시도 시간차가 2배씩 증가: 10초 -> 20초 -> 40초
+                10, TimeUnit.SECONDS, // 10초
+            )
+            .build()
+
+        workManager.enqueueUniqueWork(
+            WORK_DIARY_DOWNLOAD,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            diaryDownloadWorker
+        )
+    }
+
+    /**
+     * Firestore에 동기화 요청을 스케줄링
+     *
+     * Local DB, Firestore간 비동기화된 데이터를 동기화하는 스케줄링
+     */
+    fun scheduleDiarySync() {
+        val constraints = Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
+
+        val diarySyncWorker = OneTimeWorkRequestBuilder<DiarySyncWorker>()
+            .setConstraints(constraints)
+            .setBackoffCriteria(
+                BackoffPolicy.EXPONENTIAL,
+                10, TimeUnit.SECONDS, // 10초
+            )
+            .build()
+
+        workManager.enqueueUniqueWork(
+            WORK_DIARY_SYNC,
+            ExistingWorkPolicy.APPEND_OR_REPLACE,
+            diarySyncWorker
+        )
+    }
+
+    /**
+     * 다른 단말기에서 변경이 일어나는 데이터를 받아와서 반영하기 위한 동기화 리스너 등록
+     * Firestore 실시간 리스너를 시작하고, 변경사항을 로컬 DB에 반영
+     */
+    fun startRealtimeSync() {
+        if (listenerRegistration != null) return
+
+        val userId = auth.currentUser?.uid ?: return
+
+        val query =
+            firestore
+                .collection(COLLECTION_USERS)
+                .document(userId)
+                .collection(COLLECTION_DIARIES)
+
+        listenerRegistration = query.addSnapshotListener { snapshots, e ->
+            if (e != null) {
+                Log.e(TAG, "addSnapshotListener listen failed: ${e.message}")
+                return@addSnapshotListener
+            }
+
+            val changedDiaries = snapshots?.documentChanges?.mapNotNull { change ->
+                val firestoreDiaryDto = change.document.toObject(FirestoreDiaryDto::class.java)
+                firestoreDiaryDto.toDiaryEntity().copy(isSynced = true, isDeleted = false)
+            }
+
+            if (!changedDiaries.isNullOrEmpty()) {
+                ioScope.launch {
+                    diaryDao.upsertDiaries(changedDiaries)
+                }
+            }
+        }
+    }
+
+    /**
+     * 리소스 정리를 위해 리스너를 중지
+     */
+    fun stopRealtimeSync() {
+        listenerRegistration?.remove()
+        listenerRegistration = null
+    }
+}

--- a/data/src/main/java/kr/co/data/remote/DiarySyncWorker.kt
+++ b/data/src/main/java/kr/co/data/remote/DiarySyncWorker.kt
@@ -1,0 +1,132 @@
+package kr.co.data.remote
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.tasks.await
+import kr.co.data.local.DiaryTable.COLUMN_TIMESTAMP
+import kr.co.data.local.dao.DiaryDAO
+import kr.co.data.mapper.DiaryEntityMapper.toDiaryEntity
+import kr.co.data.mapper.DiaryEntityMapper.toFirestoreDiaryDto
+import kr.co.data.model.diary.DiaryEntity
+import kr.co.data.model.diary.FirestoreDiaryDto
+import kr.co.data.remote.FirestorePaths.COLLECTION_DIARIES
+import kr.co.data.remote.FirestorePaths.COLLECTION_USERS
+
+
+@HiltWorker
+class DiarySyncWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val diaryDao: DiaryDAO,
+    private val firestore: FirebaseFirestore,
+    private val firebaseAuth: FirebaseAuth
+) : CoroutineWorker(appContext, workerParams) {
+
+    sealed class SyncResult {
+        object LocalDataDelete : SyncResult()
+        object LocalDataUpload : SyncResult()
+        data class RemoteDataDownload(val remoteDiary: DiaryEntity) : SyncResult()
+    }
+
+    companion object {
+        const val WORK_DIARY_SYNC = "diary_sync_work"
+    }
+
+    override suspend fun doWork(): Result {
+        if (runAttemptCount > 5) Result.failure()
+        val userId = firebaseAuth.currentUser?.uid ?: return Result.failure()
+        val unsyncedDiaries = diaryDao.getUnsyncedDiaries() ?: return Result.success()
+
+        return try {
+            val localDiaryIdsToDelete = mutableListOf<Long>()
+            val localDiaryIdsToSync = mutableListOf<Long>()
+            val downloadDiaries = mutableListOf<DiaryEntity>()
+
+            unsyncedDiaries.forEach { diaryEntity ->
+                val diaryDocRef =
+                    firestore
+                        .collection(COLLECTION_USERS)
+                        .document(userId)
+                        .collection(COLLECTION_DIARIES)
+                        .document(diaryEntity.id.toString())
+
+                val result = firestore.runTransaction { transaction ->
+                    val diaryDocSnapshot = transaction.get(diaryDocRef)
+
+                    // 서버에 해당 일기가 없음
+                    if (!diaryDocSnapshot.exists()) {
+                        if (diaryEntity.isDeleted) {
+                            // 로컬에서 삭제된 일기로 -> 로컬 일기만 삭제
+                            return@runTransaction SyncResult.LocalDataDelete
+                        } else {
+                            // 로컬에 일기가 있음 -> 로컬 일기를 업로드
+                            val firestoreDiaryDto = diaryEntity.toFirestoreDiaryDto()
+                            transaction.set(diaryDocRef, firestoreDiaryDto)
+                            return@runTransaction SyncResult.LocalDataUpload
+                        }
+                    }
+
+                    // 서버에 해당 일기가 있음
+                    val remoteDiaryTimestamp = diaryDocSnapshot.getLong(COLUMN_TIMESTAMP) ?: 0L
+                    // 일기 시간 비교
+                    if (remoteDiaryTimestamp > diaryEntity.timestamp) {
+                        // 서버의 시간이 최신임으로 -> 서버 일기를 다운로드
+                        val firestoreDiaryDto = diaryDocSnapshot.toObject(FirestoreDiaryDto::class.java)!!
+                        val remoteDiary = firestoreDiaryDto.toDiaryEntity()
+                            .copy(isSynced = true, isDeleted = false)
+                        return@runTransaction SyncResult.RemoteDataDownload(remoteDiary)
+                    } else {
+                        // 로컬의 시간이 최신이지만
+                        if (diaryEntity.isDeleted) {
+                            // 로컬에서 삭제된 일기로 -> 로컬, 서버 모두 삭제
+                            transaction.delete(diaryDocRef)
+                            return@runTransaction SyncResult.LocalDataDelete
+                        } else {
+                            // 로컬에 일기가 있음 -> 로컬 일기를 업로드
+                            transaction.set(diaryDocRef, diaryEntity.toFirestoreDiaryDto())
+                            return@runTransaction SyncResult.LocalDataUpload
+                        }
+                    }
+                }.await()
+
+                // DB 처리에 필요한 id, entity 수집.
+                when (result) {
+                    is SyncResult.LocalDataUpload -> {
+                        localDiaryIdsToSync.add(diaryEntity.id)
+                    }
+
+                    is SyncResult.LocalDataDelete -> {
+                        localDiaryIdsToDelete.add(diaryEntity.id)
+                    }
+
+                    is SyncResult.RemoteDataDownload -> {
+                        downloadDiaries.add(result.remoteDiary)
+                    }
+                }
+            }
+
+            // DB 처리.
+            if (localDiaryIdsToSync.isNotEmpty()) {
+                diaryDao.updateSyncStatus(localDiaryIdsToSync, true)
+            }
+            if (localDiaryIdsToDelete.isNotEmpty()) {
+                diaryDao.deleteDiariesByIds(localDiaryIdsToDelete)
+            }
+            if (downloadDiaries.isNotEmpty()) {
+                diaryDao.upsertDiaries(downloadDiaries)
+            }
+
+            Result.success()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            if (runAttemptCount > 5) Result.failure()
+            else Result.retry()
+        }
+    }
+}

--- a/data/src/main/java/kr/co/data/remote/FirestorePath.kt
+++ b/data/src/main/java/kr/co/data/remote/FirestorePath.kt
@@ -1,0 +1,7 @@
+package kr.co.data.remote
+
+
+object FirestorePaths {
+    const val COLLECTION_USERS = "users"
+    const val COLLECTION_DIARIES = "diaries"
+}

--- a/data/src/main/java/kr/co/data/repository/DiaryRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/repository/DiaryRepositoryImpl.kt
@@ -1,0 +1,99 @@
+package kr.co.data.repository
+
+import android.util.Log
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kr.co.data.local.dao.DiaryDAO
+import kr.co.data.mapper.DiaryEntityMapper.toDiaryData
+import kr.co.data.mapper.DiaryEntityMapper.toDiaryEntity
+import kr.co.data.remote.DiaryRemoteDataSource
+import kr.co.data.source.EmotionAnalysisAiDataSource
+import kr.co.domain.exception.DiaryNotFoundException
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.model.diary.UpsertResultDiaryData
+import kr.co.domain.model.emotion.Emotion
+import kr.co.domain.repository.DiaryRepository
+import java.time.LocalDate
+import javax.inject.Inject
+
+
+class DiaryRepositoryImpl @Inject constructor(
+    private val diaryDao: DiaryDAO,
+    private val emotionAnalysisAiDataSource: EmotionAnalysisAiDataSource,
+    private val diaryRemoteDataSource: DiaryRemoteDataSource,
+) : DiaryRepository {
+
+    companion object {
+        private val TAG: String = DiaryRepositoryImpl::class.java.simpleName
+    }
+
+    override suspend fun hasDiaries(): Boolean {
+        return diaryDao.countDiaries() > 0
+    }
+
+    override suspend fun scheduleDiaryDownload(): Result<Unit> {
+        return runCatching {
+            diaryRemoteDataSource.scheduleDiaryDownload()
+        }.onFailure {
+            Log.e(TAG, "scheduleDiaryDownload: ${it.message}")
+        }
+    }
+
+    override suspend fun scheduleDiarySync(): Result<Unit> {
+        return runCatching {
+            diaryRemoteDataSource.scheduleDiarySync()
+        }.onFailure {
+            Log.e(TAG, "scheduleDiarySync: ${it.message}")
+        }
+    }
+
+    override suspend fun getDiary(date: LocalDate): Result<DiaryData> {
+        return runCatching {
+            diaryDao.getDiaryByDate(date)?.toDiaryData()
+                ?: throw DiaryNotFoundException("DiaryData not found with date: $date")
+        }.onFailure {
+            Log.e(TAG, "getDiaryByDate: ${it.message}")
+        }
+    }
+
+    override fun getDiariesFlow(startDate: LocalDate, endDate: LocalDate): Flow<List<DiaryData>> {
+        return diaryDao.getDiariesFlowByRange(startDate, endDate).map {
+            it.map { diaryEntity -> diaryEntity.toDiaryData() }
+        }
+    }
+
+    override suspend fun upsertDiary(diaryData: DiaryData): Result<UpsertResultDiaryData> {
+        return runCatching {
+            val emotionName = emotionAnalysisAiDataSource.emotionAnalysis(diaryData)
+            val timestamp = System.currentTimeMillis()
+            val diaryEntity = diaryData.toDiaryEntity()
+                .copy(
+                    emotionName = emotionName,
+                    timestamp = timestamp,
+                    isSynced = false,
+                    isDeleted = false
+                )
+
+            val diaryId = diaryDao.upsertDiary(diaryEntity)
+            val emotion = Emotion.fromString(emotionName)
+
+            diaryRemoteDataSource.scheduleDiarySync()
+
+            UpsertResultDiaryData(diaryId, emotion)
+        }.onFailure {
+            Log.e(TAG, "updateDiary: ${it.message}")
+        }
+    }
+
+    override suspend fun deleteDiary(diaryData: DiaryData): Result<Unit> {
+        return runCatching {
+            val diaryEntity = diaryData.toDiaryEntity()
+
+            diaryDao.updateDeleteStatus(diaryEntity.id, true)
+
+            diaryRemoteDataSource.scheduleDiarySync()
+        }.onFailure {
+            Log.e(TAG, "deleteDiary: ${it.message}")
+        }
+    }
+}

--- a/data/src/main/java/kr/co/data/source/CalendarLocalDataSource.kt
+++ b/data/src/main/java/kr/co/data/source/CalendarLocalDataSource.kt
@@ -11,8 +11,9 @@ import java.time.Year
 import java.time.YearMonth
 import javax.inject.Inject
 
+
 /**
- * 캘린더 관련 데이터 생성을 담당하는 클래스입니다.
+ * 캘린더 데이터 생성을 담당하는 클래스입니다.
  * Dagger를 통해 의존성 주입으로 관리됩니다.
  */
 class CalendarLocalDataSource @Inject constructor(
@@ -38,7 +39,7 @@ class CalendarLocalDataSource @Inject constructor(
      * @param year 대상 연도.
      * @return 연도 및 월별 데이터 리스트.
      */
-    fun createCalendarOf(year: Year): List<YearMonthDTO> {
+    fun createYearMonths(year: Year): List<YearMonthDTO> {
         val result = ArrayList<YearMonthDTO>(COUNT_OF_CALENDAR_ITEM)
         val quarterStartMonths =
             intArrayOf(
@@ -84,42 +85,39 @@ class CalendarLocalDataSource @Inject constructor(
         val monthDays = ArrayList<DayDTO>(COUNT_OF_ALL_DAYS)
 
         // 이전 달 날짜 계산
+        val firstDay = yearMonth.atDay(1)
         // firstDayOfWeek : yearMonth의 1일이 무슨 요일인지 정수로 반환받음 -> 월(1) ~ 일(7)
-        val firstDayOfWeek = yearMonth.atDay(1).dayOfWeek.value
+        val firstDayOfWeek = firstDay.dayOfWeek.value
         // precedingDaysCount -> 일(0) ~ 토(6)
         val precedingDaysCount = if (firstDayOfWeek == 7) 0 else firstDayOfWeek
         if (precedingDaysCount > 0) {
             val previousMonth = yearMonth.minusMonths(1)
             val prevMonthLength = previousMonth.lengthOfMonth()
             val startDay = prevMonthLength - precedingDaysCount + 1
-            for (date in startDay..prevMonthLength) {
+            for (dayOfMonth in startDay..prevMonthLength) {
+                val date = LocalDate.of(previousMonth.year, previousMonth.monthValue, dayOfMonth)
                 monthDays.add(
-                    InactiveDayDTO(
-                        date = LocalDate.of(previousMonth.year, previousMonth.monthValue, date),
-                    )
+                    InactiveDayDTO(date)
                 )
             }
         }
 
         // 현재 달 날짜 계산
         val lengthOfMonth = yearMonth.lengthOfMonth()
-        for (date in 1..lengthOfMonth) {
+        for (dayOfMonth in 1..lengthOfMonth) {
+            val date = LocalDate.of(yearMonth.year, yearMonth.monthValue, dayOfMonth)
             monthDays.add(
-                ActiveDayDTO(
-                    date = LocalDate.of(yearMonth.year, yearMonth.monthValue, date),
-                    icon = "😂",
-                )
+                ActiveDayDTO(date)
             )
         }
 
         // 다음 달 날짜 계산 (남은 공간 채우기)
         val nextMonth = yearMonth.plusMonths(1)
         val remaining = COUNT_OF_ALL_DAYS - monthDays.size
-        for (date in 1..remaining) {
+        for (dayOfMonth in 1..remaining) {
+            val date = LocalDate.of(nextMonth.year, nextMonth.monthValue, dayOfMonth)
             monthDays.add(
-                InactiveDayDTO(
-                    date = LocalDate.of(nextMonth.year, nextMonth.monthValue, date),
-                )
+                InactiveDayDTO(date)
             )
         }
 

--- a/data/src/main/java/kr/co/data/source/CalendarYearPagingSource.kt
+++ b/data/src/main/java/kr/co/data/source/CalendarYearPagingSource.kt
@@ -40,7 +40,7 @@ class CalendarYearPagingSource(
                 if (firstYear == null) firstYear = year
                 lastYear = year
 
-                gridItems.addAll(calendarLocalDataSource.createCalendarOf(year))
+                gridItems.addAll(calendarLocalDataSource.createYearMonths(year))
             }
 
             if (gridItems.isEmpty()) {

--- a/data/src/main/java/kr/co/data/source/EmotionAnalysisAiDataSource.kt
+++ b/data/src/main/java/kr/co/data/source/EmotionAnalysisAiDataSource.kt
@@ -1,0 +1,36 @@
+package kr.co.data.source
+
+import android.util.Log
+import com.google.ai.client.generativeai.GenerativeModel
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.model.emotion.Emotion
+import javax.inject.Inject
+
+
+class EmotionAnalysisAiDataSource @Inject constructor(
+    private val generativeModel: GenerativeModel
+) {
+    private val tag: String = this::class.java.simpleName
+
+    suspend fun emotionAnalysis(diaryData: DiaryData): String {
+        val emotions = Emotion.entries.joinToString(", ") { it.name }
+
+        val prompt = """
+                일기 제목과 내용을 분석하고 [$emotions] 목록 중 
+                감정 1개만 선택해줘.
+                결과는 반드시 선택한 감정 1개만 출력해줘.
+                
+                제목: ${diaryData.title}
+                내용: ${diaryData.content}
+            """.trimIndent()
+
+        try {
+            val response = generativeModel.generateContent(prompt)
+            val emotion = response.text?.trim() ?: Emotion.UNKNOWN.name
+            return emotion
+        } catch (e: Exception){
+            Log.e(tag, "emotionAnalysisAi: ${e.message}")
+            return Emotion.UNKNOWN.name
+        }
+    }
+}

--- a/domain/src/main/java/kr/co/domain/exception/DiaryException.kt
+++ b/domain/src/main/java/kr/co/domain/exception/DiaryException.kt
@@ -1,0 +1,8 @@
+package kr.co.domain.exception
+
+
+/** 다이어리 관련 비즈니스 규칙을 위반했을 때 발생하는 최상위 예외 */
+open class DiaryException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/** 요청한 다이어리를 찾을 수 없을 때 발생하는 예외 */
+class DiaryNotFoundException(message: String) : DiaryException(message)

--- a/domain/src/main/java/kr/co/domain/extention/ConverterExtentions.kt
+++ b/domain/src/main/java/kr/co/domain/extention/ConverterExtentions.kt
@@ -1,0 +1,8 @@
+package kr.co.domain.extention
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+
+fun LocalDate.dateToString(): String = this.format(DateTimeFormatter.ISO_LOCAL_DATE)
+fun String.toLocalDate(): LocalDate = LocalDate.parse(this, DateTimeFormatter.ISO_LOCAL_DATE)

--- a/domain/src/main/java/kr/co/domain/model/calendar/day/ActiveDayData.kt
+++ b/domain/src/main/java/kr/co/domain/model/calendar/day/ActiveDayData.kt
@@ -5,5 +5,4 @@ import java.time.LocalDate
 
 data class ActiveDayData(
     override val date: LocalDate = LocalDate.now(),
-    val icon: String = "",
 ) : DayData

--- a/domain/src/main/java/kr/co/domain/model/diary/DiaryData.kt
+++ b/domain/src/main/java/kr/co/domain/model/diary/DiaryData.kt
@@ -1,0 +1,16 @@
+package kr.co.domain.model.diary
+
+import kr.co.domain.model.emotion.Emotion
+import java.time.LocalDate
+
+
+data class DiaryData(
+    val id: Long = 0L,
+    val date: LocalDate = LocalDate.now(),
+    val title: String = "",
+    val content: String = "",
+    val emotion: Emotion = Emotion.UNKNOWN,
+    val timestamp: Long = 0L,
+    val isSynced: Boolean = false,
+    val isDeleted: Boolean = false,
+)

--- a/domain/src/main/java/kr/co/domain/model/diary/UpsertResultDiaryData.kt
+++ b/domain/src/main/java/kr/co/domain/model/diary/UpsertResultDiaryData.kt
@@ -1,0 +1,9 @@
+package kr.co.domain.model.diary
+
+import kr.co.domain.model.emotion.Emotion
+
+
+data class UpsertResultDiaryData(
+    val id: Long = 0L,
+    val emotion: Emotion = Emotion.UNKNOWN,
+)

--- a/domain/src/main/java/kr/co/domain/model/emotion/Emotion.kt
+++ b/domain/src/main/java/kr/co/domain/model/emotion/Emotion.kt
@@ -1,0 +1,63 @@
+package kr.co.domain.model.emotion
+
+
+enum class Emotion {
+    // 1. 긍정 & 활력 (Positive & High Energy)
+    JOY,                    // 기쁨
+    EXCITEMENT,             // 흥분됨, 신남
+    TRIUMPH,                // 승리감
+    AMUSEMENT,              // 즐거움
+
+    // 2. 사랑 & 애정 (Love & Affection)
+    ROMANCE,                // 로맨스
+    ADORATION,              // 흠모
+    SEXUAL_DESIRE,          // 성적 욕구
+
+    // 3. 차분함 & 심미 (Calm & Aesthetic)
+    CALMNESS,               // 차분함
+    SATISFACTION,           // 만족
+    AESTHETIC_APPRECIATION, // 심미적 감상
+    ENTRANCEMENT,           // 황홀경
+
+    // 4. 존경 & 관심 (Respect & Interest)
+    ADMIRATION,             // 존경
+    AWE,                    // 경외감
+    INTEREST,               // 흥미, 호기심
+
+    // 5. 슬픔 & 그리움 (Sadness & Longing)
+    SADNESS,                // 슬픔
+    NOSTALGIA,              // 향수, 그리움
+    SYMPATHY,               // 공감
+    EMPATHETIC_PAIN,        // 공감적 고통
+
+    // 6. 부정 & 경계 (Negative & Alert)
+    ANGER,                  // 분노
+    FEAR,                   // 두려움
+    HORROR,                 // 공포
+    ANXIETY,                // 걱정
+
+    // 7. 복합 & 모호 (Complex & Ambiguous)
+    CONFUSION,              // 혼란스러움
+    BOREDOM,                // 지루함
+    AWKWARDNESS,            // 어색함
+    DISGUST,                // 역겨움
+    ENVY,                   // 부러움, 질투
+
+    // 8. 욕구 (Desire)
+    CRAVING,                // 간절함
+
+    // 9. 미정 및 기본값 (Undefined / Default)
+    UNKNOWN;                // 알 수 없음, 분석 전, 데이터 없음
+
+    companion object {
+        // AI 응답(String)을 Enum으로 변환 (대소문자/띄어쓰기 무시)
+        // 띄어쓰기나 대소문자를 무시하고 매칭 (예: "Sexual desire" -> SEXUAL_DESIRE)
+        fun fromString(value: String): Emotion {
+
+            val normalized = value.trim()
+            return entries.find {
+                it.name.equals(normalized, ignoreCase = true)
+            } ?: UNKNOWN
+        }
+    }
+}

--- a/domain/src/main/java/kr/co/domain/repository/DiaryRepository.kt
+++ b/domain/src/main/java/kr/co/domain/repository/DiaryRepository.kt
@@ -1,0 +1,17 @@
+package kr.co.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.model.diary.UpsertResultDiaryData
+import java.time.LocalDate
+
+
+interface DiaryRepository {
+    suspend fun hasDiaries(): Boolean
+    suspend fun scheduleDiaryDownload(): Result<Unit>
+    suspend fun scheduleDiarySync(): Result<Unit>
+    suspend fun getDiary(date: LocalDate): Result<DiaryData>
+    fun getDiariesFlow(startDate: LocalDate, endDate: LocalDate): Flow<List<DiaryData>>
+    suspend fun upsertDiary(diaryData: DiaryData): Result<UpsertResultDiaryData>
+    suspend fun deleteDiary(diaryData: DiaryData): Result<Unit>
+}

--- a/domain/src/main/java/kr/co/domain/usecase/auth/IsUserLoggedInUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/auth/IsUserLoggedInUseCase.kt
@@ -1,4 +1,4 @@
-package kr.co.domain.usecase
+package kr.co.domain.usecase.auth
 
 import kr.co.domain.model.auth.User
 import kr.co.domain.repository.AuthRepository

--- a/domain/src/main/java/kr/co/domain/usecase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/auth/LoginUseCase.kt
@@ -1,4 +1,4 @@
-package kr.co.domain.usecase
+package kr.co.domain.usecase.auth
 
 import kr.co.domain.model.auth.User
 import kr.co.domain.repository.AuthRepository

--- a/domain/src/main/java/kr/co/domain/usecase/auth/SignUpUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/auth/SignUpUseCase.kt
@@ -1,4 +1,4 @@
-package kr.co.domain.usecase
+package kr.co.domain.usecase.auth
 
 import kr.co.domain.model.auth.User
 import kr.co.domain.repository.AuthRepository

--- a/domain/src/main/java/kr/co/domain/usecase/calendar/GetCalendarMonthUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/calendar/GetCalendarMonthUseCase.kt
@@ -1,4 +1,4 @@
-package kr.co.domain.usecase
+package kr.co.domain.usecase.calendar
 
 import kr.co.domain.repository.CalendarRepository
 import java.time.YearMonth

--- a/domain/src/main/java/kr/co/domain/usecase/calendar/GetCalendarYearUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/calendar/GetCalendarYearUseCase.kt
@@ -1,4 +1,4 @@
-package kr.co.domain.usecase
+package kr.co.domain.usecase.calendar
 
 import kr.co.domain.repository.CalendarRepository
 import java.time.Year

--- a/domain/src/main/java/kr/co/domain/usecase/diary/CheckAndDownloadInitialDiariesUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/CheckAndDownloadInitialDiariesUseCase.kt
@@ -1,0 +1,15 @@
+package kr.co.domain.usecase.diary
+
+import kr.co.domain.repository.DiaryRepository
+import javax.inject.Inject
+
+
+class CheckAndDownloadInitialDiariesUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository
+) {
+    suspend operator fun invoke() {
+        if (!diaryRepository.hasDiaries()) {
+            diaryRepository.scheduleDiaryDownload()
+        }
+    }
+}

--- a/domain/src/main/java/kr/co/domain/usecase/diary/DeleteDiaryUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/DeleteDiaryUseCase.kt
@@ -1,0 +1,14 @@
+package kr.co.domain.usecase.diary
+
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.repository.DiaryRepository
+import javax.inject.Inject
+
+
+class DeleteDiaryUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository,
+) {
+    suspend operator fun invoke(diaryData: DiaryData): Result<Unit> {
+        return diaryRepository.deleteDiary(diaryData)
+    }
+}

--- a/domain/src/main/java/kr/co/domain/usecase/diary/GetDiariesUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/GetDiariesUseCase.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.usecase.diary
+
+import kotlinx.coroutines.flow.Flow
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.repository.DiaryRepository
+import java.time.YearMonth
+import javax.inject.Inject
+
+
+class GetDiariesUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository
+) {
+    operator fun invoke(centerMonth: YearMonth, monthRange: Long = 1L): Flow<List<DiaryData>> {
+        val startDate = centerMonth.minusMonths(monthRange).atDay(1)
+        val endDate = centerMonth.plusMonths(monthRange).atEndOfMonth()
+        return diaryRepository.getDiariesFlow(startDate, endDate)
+    }
+}

--- a/domain/src/main/java/kr/co/domain/usecase/diary/GetDiaryUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/GetDiaryUseCase.kt
@@ -1,0 +1,15 @@
+package kr.co.domain.usecase.diary
+
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.repository.DiaryRepository
+import java.time.LocalDate
+import javax.inject.Inject
+
+
+class GetDiaryUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository,
+) {
+    suspend operator fun invoke(date: LocalDate): Result<DiaryData> {
+        return diaryRepository.getDiary(date)
+    }
+}

--- a/domain/src/main/java/kr/co/domain/usecase/diary/SyncDiaryUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/SyncDiaryUseCase.kt
@@ -1,0 +1,13 @@
+package kr.co.domain.usecase.diary
+
+import kr.co.domain.repository.DiaryRepository
+import javax.inject.Inject
+
+
+class SyncDiaryUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository,
+){
+    suspend operator fun invoke() {
+        diaryRepository.scheduleDiarySync()
+    }
+}

--- a/domain/src/main/java/kr/co/domain/usecase/diary/UpsertDiaryUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/usecase/diary/UpsertDiaryUseCase.kt
@@ -1,0 +1,15 @@
+package kr.co.domain.usecase.diary
+
+import kr.co.domain.model.diary.DiaryData
+import kr.co.domain.model.diary.UpsertResultDiaryData
+import kr.co.domain.repository.DiaryRepository
+import javax.inject.Inject
+
+
+class UpsertDiaryUseCase @Inject constructor(
+    private val diaryRepository: DiaryRepository,
+){
+    suspend operator fun invoke(diaryData: DiaryData): Result<UpsertResultDiaryData> {
+        return diaryRepository.upsertDiary(diaryData)
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,13 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.resvalues=true
+android.enableAppCompileTimeRClass=false
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.13.2"
+agp = "9.0.0"
 coreSplashscreen = "1.0.1"
 datastorePreferences = "1.1.4"
 firebaseBom = "33.13.0"
@@ -7,8 +7,8 @@ hilt = "2.56.2"
 hiltNavigationCompose = "1.2.0"
 javaxInject = "1"
 coroutines = "1.8.0"
-ksp = "2.1.20-2.0.0"
-kotlin = "2.1.20"
+ksp = "2.3.2"
+kotlin = "2.2.10"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"
@@ -21,9 +21,13 @@ appcompat = "1.7.0"
 navigationCompose = "2.8.9"
 orbit = "6.1.0"
 paging = "3.3.6"
-#serialization = "2.1.20"
 firebase = "4.4.2"
 immutable = "0.4.0"
+room = "2.8.4"
+generativeAi = "0.9.0"
+work = "2.9.0"
+hiltWork = "1.2.0"
+secrets = "2.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,6 +43,7 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging" }
 androidx-paging-common = { module = "androidx.paging:paging-common", version.ref = "paging" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
@@ -50,10 +55,14 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics-ktx = { module = "com.google.firebase:firebase-analytics-ktx" }
 firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx" }
+firebase-firestore-ktx = { module = "com.google.firebase:firebase-firestore-ktx" }
 
-#hilt
+#hilt-android
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+#hilt-work
+hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
 
 #compose-bom
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
@@ -70,6 +79,15 @@ androidx-foundation = { module = "androidx.compose.foundation:foundation" }
 orbit-compose = { module = "org.orbit-mvi:orbit-compose", version.ref = "orbit" }
 orbit-viewmodel = { module = "org.orbit-mvi:orbit-viewmodel", version.ref = "orbit" }
 
+#room
+androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
+androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
+
+#google generative ai
+generative-ai = { module = "com.google.ai.client.generativeai:generativeai", version.ref = "generativeAi" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
@@ -77,6 +95,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 firebase = { id = "com.google.gms.google-services", version.ref = "firebase" }
+secrets = { id = "com.google.android.libraries.mapsplatform.secrets-gradle-plugin", version.ref = "secrets" }
 
 #kotlin
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 28 17:58:12 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/presentation/src/main/java/kr/co/presentation/mapper/CalendarItemMapper.kt
+++ b/presentation/src/main/java/kr/co/presentation/mapper/CalendarItemMapper.kt
@@ -40,7 +40,6 @@ object CalendarItemMapper {
         return when (this) {
             is ActiveDayData -> ActiveDayItem(
                 date = date,
-                icon = icon,
             )
 
             is InactiveDayData -> InactiveDayItem(

--- a/presentation/src/main/java/kr/co/presentation/mapper/UiDiaryMapper.kt
+++ b/presentation/src/main/java/kr/co/presentation/mapper/UiDiaryMapper.kt
@@ -1,0 +1,23 @@
+package kr.co.presentation.mapper
+
+import kr.co.domain.model.diary.DiaryData
+import kr.co.presentation.ui.model.common.UiDiary
+
+
+object UiDiaryMapper {
+    fun DiaryData.toUiDiary() = UiDiary(
+        id = id,
+        date = date,
+        title = title,
+        content = content,
+        emotion = emotion,
+    )
+
+    fun UiDiary.toDiaryData() = DiaryData(
+        id = id,
+        date = date,
+        title = title,
+        content = content,
+        emotion = emotion,
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/mapper/UserMapper.kt
+++ b/presentation/src/main/java/kr/co/presentation/mapper/UserMapper.kt
@@ -5,11 +5,9 @@ import kr.co.presentation.ui.model.common.UiUser
 
 
 object UserMapper {
-    fun User.toUiUser(): UiUser {
-        return UiUser(
-            name = this.name,
-            email = this.email,
-            photoUrl = this.photoUrl,
-        )
-    }
+    fun User.toUiUser() = UiUser(
+        name = this.name,
+        email = this.email,
+        photoUrl = this.photoUrl,
+    )
 }

--- a/presentation/src/main/java/kr/co/presentation/ui/component/calendar/day/ActiveDay.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/component/calendar/day/ActiveDay.kt
@@ -3,8 +3,12 @@ package kr.co.presentation.ui.component.calendar.day
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -15,9 +19,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import kr.co.presentation.ui.extension.isAfterToday
+import androidx.compose.ui.unit.dp
+import kr.co.domain.model.emotion.Emotion
 import kr.co.presentation.ui.extension.isToday
 import kr.co.presentation.ui.model.calendar.day.ActiveDayItem
+import kr.co.presentation.ui.extension.color
+import kr.co.presentation.ui.model.common.UiDiary
 import kr.co.presentation.ui.theme.MinaryTheme
 import java.time.LocalDate
 
@@ -26,8 +33,9 @@ import java.time.LocalDate
 fun ActiveDay(
     modifier: Modifier = Modifier,
     dayItem: ActiveDayItem,
+    diary: UiDiary? = null,
     isIconVisible: Boolean = false,
-    onClick: ((LocalDate) -> Unit)? = null
+    onClick: ((ActiveDayItem) -> Unit)? = null
 ) {
     val isToday = dayItem.isToday()
 
@@ -42,7 +50,7 @@ fun ActiveDay(
             .aspectRatio(1f)
             .clickable(
                 enabled = (onClick != null),
-                onClick = { onClick?.invoke(dayItem.date) }
+                onClick = { onClick?.invoke(dayItem) }
             )
             .clip(shape)
             .background(color),
@@ -57,9 +65,16 @@ fun ActiveDay(
         )
 
         if (isIconVisible) {
-            dayItem.icon?.let {
-                if (!dayItem.isAfterToday())
-                    Text(text = it)
+            if (diary != null) {
+                Box(
+                    modifier = Modifier
+                        .padding(6.dp)
+                        .size(6.dp)
+                        .clip(CircleShape)
+                        .background(diary.emotion.color, CircleShape)
+                )
+            } else {
+                Spacer(modifier = Modifier.padding(6.dp).size(6.dp))
             }
         }
     }
@@ -70,7 +85,12 @@ fun ActiveDay(
 private fun ActiveDayPreview() {
     MinaryTheme {
         ActiveDay(
-            dayItem = ActiveDayItem(),
+            dayItem = ActiveDayItem(
+                date = LocalDate.now(),
+            ),
+            diary = UiDiary(
+                emotion = Emotion.TRIUMPH,
+            ),
             isIconVisible = true,
         )
     }

--- a/presentation/src/main/java/kr/co/presentation/ui/component/calendar/day/InactiveDay.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/component/calendar/day/InactiveDay.kt
@@ -3,7 +3,10 @@ package kr.co.presentation.ui.component.calendar.day
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,6 +16,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import kr.co.presentation.ui.model.calendar.day.InactiveDayItem
 import kr.co.presentation.ui.theme.MinaryTheme
 
@@ -36,6 +40,8 @@ fun InactiveDay(
             color = Color.LightGray,
             fontWeight = FontWeight.Normal,
         )
+
+        Spacer(modifier = Modifier.padding(6.dp).size(6.dp))
     }
 }
 

--- a/presentation/src/main/java/kr/co/presentation/ui/extension/CalendarExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/extension/CalendarExtensions.kt
@@ -9,51 +9,19 @@ import java.time.YearMonth
 
 
 // java class extensions
-fun Year.isCurrentYear(): Boolean {
-    return this == Year.now()
-}
-
-fun Year.isAfterCurrentYear(): Boolean {
-    return this.isAfter(Year.now())
-}
-
-fun YearMonth.isCurrentYearMonth(): Boolean {
-    return this == YearMonth.now()
-}
-
-fun YearMonth.isAfterCurrentYearMonth(): Boolean {
-    return this.isAfter(YearMonth.now())
-}
-
-fun LocalDate.isToday(): Boolean {
-    return this == LocalDate.now()
-}
-
-fun LocalDate.isAfterToday(): Boolean {
-    return this.isAfter(LocalDate.now())
-}
+fun Year.isCurrentYear(): Boolean = this == Year.now()
+fun Year.isAfterCurrentYear(): Boolean = this.isAfter(Year.now())
+fun YearMonth.isCurrentYearMonth(): Boolean = this == YearMonth.now()
+fun YearMonth.isAfterCurrentYearMonth(): Boolean = this.isAfter(YearMonth.now())
+fun LocalDate.isToday(): Boolean = this == LocalDate.now()
+fun LocalDate.isAfterToday(): Boolean = this.isAfter(LocalDate.now())
 
 // minary class extensions
-fun YearItem.isCurrentYear(): Boolean {
-    return year == Year.now()
-}
-
-fun YearItem.isAfterCurrentYear(): Boolean {
-    return year.isAfter(Year.now())
-}
-
-fun MonthItem.isCurrentMonth(): Boolean {
-    return yearMonth == YearMonth.now()
-}
-
-fun MonthItem.isAfterCurrentYearMonth(): Boolean {
-    return yearMonth.isAfter(YearMonth.now())
-}
-
-fun DayItem.isToday(): Boolean {
-    return date == LocalDate.now()
-}
-
-fun DayItem.isAfterToday(): Boolean {
-    return date.isAfter(LocalDate.now())
-}
+fun YearItem.isCurrentYear(): Boolean = year == Year.now()
+fun YearItem.isAfterCurrentYear(): Boolean = year.isAfter(Year.now())
+fun MonthItem.isCurrentMonth(): Boolean = yearMonth == YearMonth.now()
+fun MonthItem.isAfterCurrentYearMonth(): Boolean = yearMonth.isAfter(YearMonth.now())
+fun DayItem.isToday(): Boolean = date == LocalDate.now()
+fun DayItem.isAfterToday(): Boolean = date.isAfter(LocalDate.now())
+fun DayItem.toYear(): Year = Year.of(date.year)
+fun DayItem.toYearMonth(): YearMonth = YearMonth.of(date.year, date.monthValue)

--- a/presentation/src/main/java/kr/co/presentation/ui/extension/EmotionExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/extension/EmotionExtensions.kt
@@ -1,0 +1,107 @@
+package kr.co.presentation.ui.extension
+
+import androidx.compose.ui.graphics.Color
+import kr.co.domain.model.emotion.Emotion
+import kr.co.presentation.R
+
+
+// 확장 프로퍼티를 사용하여 Enum에 색상 기능을 '주입'합니다.
+val Emotion.color: Color
+    get() = when (this) {
+        // 1. 긍정 & 활력 (Positive & High Energy)
+        Emotion.JOY -> Color(0xFFFFD700)                    // Gold
+        Emotion.EXCITEMENT -> Color(0xFFFF8C00)             // Dark Orange
+        Emotion.TRIUMPH -> Color(0xFFDAA520)                // Goldenrod
+        Emotion.AMUSEMENT -> Color(0xFFFF69B4)              // Hot Pink
+
+        // 2. 사랑 & 애정 (Love & Affection)
+        Emotion.ROMANCE -> Color(0xFFFF1493)                // Deep Pink
+        Emotion.ADORATION -> Color(0xFFFFB6C1)              // Light Pink
+        Emotion.SEXUAL_DESIRE -> Color(0xFF800020)          // Burgundy
+
+        // 3. 차분함 & 심미 (Calm & Aesthetic)
+        Emotion.CALMNESS -> Color(0xFF98FB98)               // Pale Green
+        Emotion.SATISFACTION -> Color(0xFF2E8B57)           // Sea Green
+        Emotion.AESTHETIC_APPRECIATION -> Color(0xFFE6E6FA) // Lavender
+        Emotion.ENTRANCEMENT -> Color(0xFF9370DB)           // Medium Purple
+
+        // 4. 존경 & 관심 (Respect & Interest)
+        Emotion.ADMIRATION -> Color(0xFF4682B4)             // Steel Blue
+        Emotion.AWE -> Color(0xFF4B0082)                    // Indigo
+        Emotion.INTEREST -> Color(0xFF00CED1)               // Dark Turquoise
+
+        // 5. 슬픔 & 그리움 (Sadness & Longing)
+        Emotion.SADNESS -> Color(0xFF4169E1)                // Royal Blue
+        Emotion.NOSTALGIA -> Color(0xFFD2691E)              // Chocolate/Sepia
+        Emotion.SYMPATHY -> Color(0xFFFFA07A)               // Light Salmon
+        Emotion.EMPATHETIC_PAIN -> Color(0xFFBC8F8F)        // Rosy Brown
+
+        // 6. 부정 & 경계 (Negative & Alert)
+        Emotion.ANGER -> Color(0xFFFF0000)                  // Red
+        Emotion.FEAR -> Color(0xFF2F4F4F)                   // Dark Slate Gray
+        Emotion.HORROR -> Color(0xFF000000)                 // Black
+        Emotion.ANXIETY -> Color(0xFF708090)                // Slate Gray
+
+        // 7. 복합 & 모호 (Complex & Ambiguous)
+        Emotion.CONFUSION -> Color(0xFFD8BFD8)              // Thistle
+        Emotion.BOREDOM -> Color(0xFFA9A9A9)                // Dark Gray
+        Emotion.AWKWARDNESS -> Color(0xFFBDB76B)            // Dark Khaki
+        Emotion.DISGUST -> Color(0xFF556B2F)                // Dark Olive Green
+        Emotion.ENVY -> Color(0xFF32CD32)                   // Lime Green
+
+        // 8. 욕구 (Desire)
+        Emotion.CRAVING -> Color(0xFFFF4500)                // Orange Red
+
+        // 9. 미정 및 기본값 (Undefined / Default)
+        Emotion.UNKNOWN -> Color(0xFFC0C0C0)                // Silver
+    }
+
+val Emotion.resId: Int
+    get() = when (this) {
+        // 1. 긍정 & 활력 (Positive & High Energy)
+        Emotion.JOY -> R.string.emotion_joy
+        Emotion.EXCITEMENT -> R.string.emotion_excitement
+        Emotion.TRIUMPH -> R.string.emotion_triumph
+        Emotion.AMUSEMENT -> R.string.emotion_amusement
+
+        // 2. 사랑 & 애정 (Love & Affection)
+        Emotion.ROMANCE -> R.string.emotion_romance
+        Emotion.ADORATION -> R.string.emotion_adoration
+        Emotion.SEXUAL_DESIRE -> R.string.emotion_sexual_desire
+
+        // 3. 차분함 & 심미 (Calm & Aesthetic)
+        Emotion.CALMNESS -> R.string.emotion_calmness
+        Emotion.SATISFACTION -> R.string.emotion_satisfaction
+        Emotion.AESTHETIC_APPRECIATION -> R.string.emotion_aesthetic_appreciation
+        Emotion.ENTRANCEMENT -> R.string.emotion_entrancement
+
+        // 4. 존경 & 관심 (Respect & Interest)
+        Emotion.ADMIRATION -> R.string.emotion_admiration
+        Emotion.AWE -> R.string.emotion_awe
+        Emotion.INTEREST -> R.string.emotion_interest
+
+        // 5. 슬픔 & 그리움 (Sadness & Longing)
+        Emotion.SADNESS -> R.string.emotion_sadness
+        Emotion.NOSTALGIA -> R.string.emotion_nostalgia
+        Emotion.SYMPATHY -> R.string.emotion_sympathy
+        Emotion.EMPATHETIC_PAIN -> R.string.emotion_empathetic_pain
+
+        // 6. 부정 & 경계 (Negative & Alert)
+        Emotion.ANGER -> R.string.emotion_anger
+        Emotion.FEAR -> R.string.emotion_fear
+        Emotion.HORROR -> R.string.emotion_horror
+        Emotion.ANXIETY -> R.string.emotion_anxiety
+
+        // 7. 복합 & 모호 (Complex & Ambiguous)
+        Emotion.CONFUSION -> R.string.emotion_confusion
+        Emotion.BOREDOM -> R.string.emotion_boredom
+        Emotion.AWKWARDNESS -> R.string.emotion_awkwardness
+        Emotion.DISGUST -> R.string.emotion_disgust
+        Emotion.ENVY -> R.string.emotion_envy
+
+        // 8. 욕구 (Desire)
+        Emotion.CRAVING -> R.string.emotion_craving
+
+        // 9. 미정 및 기본값 (Undefined / Default)
+        Emotion.UNKNOWN -> R.string.emotion_unknown
+    }

--- a/presentation/src/main/java/kr/co/presentation/ui/model/calendar/day/ActiveDayItem.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/model/calendar/day/ActiveDayItem.kt
@@ -1,6 +1,7 @@
 package kr.co.presentation.ui.model.calendar.day
 
 import androidx.compose.runtime.Immutable
+import kr.co.domain.model.emotion.Emotion
 import kr.co.presentation.ui.model.calendar.BaseItem
 import java.time.LocalDate
 
@@ -8,7 +9,6 @@ import java.time.LocalDate
 @Immutable
 data class ActiveDayItem(
     override val date: LocalDate = LocalDate.now(),
-    val icon: String = "\uD83D\uDE02",
 
     override val key: String = "${date.year}-${date.monthValue}-${date.dayOfMonth}",
     override val contentType: BaseItem.ContentType = BaseItem.ContentType.DATE,

--- a/presentation/src/main/java/kr/co/presentation/ui/model/common/UiDiary.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/model/common/UiDiary.kt
@@ -1,0 +1,15 @@
+package kr.co.presentation.ui.model.common
+
+import androidx.compose.runtime.Immutable
+import kr.co.domain.model.emotion.Emotion
+import java.time.LocalDate
+
+
+@Immutable
+data class UiDiary(
+    val id: Long = 0L,
+    val date: LocalDate = LocalDate.now(),
+    val title: String = "",
+    val content: String = "",
+    val emotion: Emotion = Emotion.UNKNOWN,
+)

--- a/presentation/src/main/java/kr/co/presentation/ui/navigation/graph/CalendarNavGraph.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/navigation/graph/CalendarNavGraph.kt
@@ -5,33 +5,32 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import androidx.navigation.toRoute
 import kr.co.presentation.ui.navigation.route.CalendarGraph
 import kr.co.presentation.ui.navigation.route.MonthlyCalendar
 import kr.co.presentation.ui.navigation.route.YearlyCalender
 import kr.co.presentation.ui.screen.contents.calendar.MonthlyCalendarScreen
 import kr.co.presentation.ui.screen.contents.calendar.YearlyCalendarScreen
-import java.time.LocalDate
-import java.time.Year
+import kr.co.presentation.viewmodel.main.MainIntent
 import java.time.YearMonth
 
 
 internal fun NavGraphBuilder.calenderNavGraph(
     navController: NavHostController,
-    onNavigateToDiaryScreen: (LocalDate) -> Unit,
+    intent: (MainIntent) -> Unit = {},
 ) {
     val currentYearMonth = YearMonth.now()
-    val currentYear = currentYearMonth.year
-    val currentMonth = currentYearMonth.monthValue
 
-    navigation<CalendarGraph>(startDestination = MonthlyCalendar(currentYear, currentMonth)) {
+    navigation<CalendarGraph>(
+        startDestination = MonthlyCalendar(
+            year = currentYearMonth.year,
+            month = currentYearMonth.monthValue
+        )
+    ) {
 
-        composable<MonthlyCalendar> { backStackEntry ->
-            val monthCalender: MonthlyCalendar = backStackEntry.toRoute()
+        composable<MonthlyCalendar> {
             MonthlyCalendarScreen(
-                yearMonth = YearMonth.of(monthCalender.year, monthCalender.month),
                 onNavigateToDiaryScreen = { date ->
-                    onNavigateToDiaryScreen(date)
+                    intent(MainIntent.NavigateToDiaryScreen(date))
                 },
                 onNavigateToYearlyCalendar = { year ->
                     navController.navigate(YearlyCalender(year)) {
@@ -43,9 +42,7 @@ internal fun NavGraphBuilder.calenderNavGraph(
         }
 
         composable<YearlyCalender> { backStackEntry ->
-            val yearlyCalender: YearlyCalender = backStackEntry.toRoute()
             YearlyCalendarScreen(
-                year = Year.of(yearlyCalender.year),
                 onNavigateToMonthlyCalendar = { yearMonth ->
                     navController.navigate(MonthlyCalendar(yearMonth.year, yearMonth.monthValue)) {
                         popUpTo(navController.graph.findStartDestination().id) {

--- a/presentation/src/main/java/kr/co/presentation/ui/navigation/graph/MainNavGraph.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/navigation/graph/MainNavGraph.kt
@@ -4,13 +4,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
-import androidx.navigation.toRoute
 import kr.co.presentation.ui.navigation.route.Diary
 import kr.co.presentation.ui.navigation.route.Main
 import kr.co.presentation.ui.navigation.route.MainGraph
 import kr.co.presentation.ui.screen.diary.DiaryScreen
 import kr.co.presentation.ui.screen.main.MainScreen
-import java.time.LocalDate
 
 
 internal fun NavGraphBuilder.mainNavGraph(
@@ -21,16 +19,14 @@ internal fun NavGraphBuilder.mainNavGraph(
             MainScreen(
                 onNavigateToDiaryScreen = { date ->
                     navController.navigate(Diary(date.year, date.monthValue, date.dayOfMonth))
-                }
+                },
             )
         }
-        composable<Diary> { backStackEntry ->
-            val diary: Diary = backStackEntry.toRoute()
+        composable<Diary> {
             DiaryScreen(
-                date = LocalDate.of(diary.year, diary.month, diary.date),
                 onNavigateToMainScreen = {
                     navController.popBackStack()
-                }
+                },
             )
         }
     }

--- a/presentation/src/main/java/kr/co/presentation/ui/navigation/host/MainNavHost.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/navigation/host/MainNavHost.kt
@@ -10,6 +10,7 @@ import kr.co.presentation.ui.navigation.graph.dashBoardNavGraph
 import kr.co.presentation.ui.navigation.graph.settingNavGraph
 import kr.co.presentation.ui.navigation.graph.storeNavGraph
 import kr.co.presentation.ui.navigation.route.AppRoute
+import kr.co.presentation.viewmodel.main.MainIntent
 import java.time.LocalDate
 
 
@@ -18,10 +19,10 @@ fun MainNavHost(
     navController: NavHostController = rememberNavController(),
     startDestination: AppRoute,
     modifier: Modifier,
-    onNavigateToDiaryScreen: (LocalDate) -> Unit,
+    intent: (MainIntent) -> Unit = {},
 ) {
     NavHost(navController, startDestination, modifier) {
-        calenderNavGraph(navController, onNavigateToDiaryScreen)
+        calenderNavGraph(navController, intent)
         dashBoardNavGraph(navController)
         storeNavGraph(navController)
         settingNavGraph(navController)

--- a/presentation/src/main/java/kr/co/presentation/ui/navigation/route/AppRoute.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/navigation/route/AppRoute.kt
@@ -1,7 +1,6 @@
 package kr.co.presentation.ui.navigation.route
 
 import kotlinx.serialization.Serializable
-import java.time.YearMonth
 
 
 @Serializable

--- a/presentation/src/main/java/kr/co/presentation/ui/preview/CalendarPreviewDataFactory.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/preview/CalendarPreviewDataFactory.kt
@@ -2,12 +2,15 @@ package kr.co.presentation.ui.preview
 
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
+import kr.co.domain.model.emotion.Emotion
+import kr.co.presentation.ui.extension.isAfterToday
 import kr.co.presentation.ui.model.calendar.day.ActiveDayItem
 import kr.co.presentation.ui.model.calendar.day.DayItem
 import kr.co.presentation.ui.model.calendar.day.InactiveDayItem
 import kr.co.presentation.ui.model.calendar.yearmonth.MonthItem
 import kr.co.presentation.ui.model.calendar.yearmonth.YearItem
 import kr.co.presentation.ui.model.calendar.yearmonth.YearMonthItem
+import kr.co.presentation.ui.screen.diary.EmotionIcon
 import java.time.LocalDate
 import java.time.Year
 import java.time.YearMonth
@@ -101,34 +104,30 @@ object CalendarPreviewDataFactory {
             val previousMonth = yearMonth.minusMonths(1)
             val prevMonthLength = previousMonth.lengthOfMonth()
             val startDay = prevMonthLength - precedingDaysCount + 1
-            for (date in startDay..prevMonthLength) {
+            for (dayOfMonth in startDay..prevMonthLength) {
+                val date = LocalDate.of(previousMonth.year, previousMonth.monthValue, dayOfMonth)
                 monthDays.add(
-                    InactiveDayItem(
-                        date = LocalDate.of(previousMonth.year, previousMonth.monthValue, date),
-                    )
+                    InactiveDayItem(date)
                 )
             }
         }
 
         // 현재 달 날짜 계산
         val lengthOfMonth = yearMonth.lengthOfMonth()
-        for (date in 1..lengthOfMonth) {
+        for (dayOfMonth in 1..lengthOfMonth) {
+            val date = LocalDate.of(yearMonth.year, yearMonth.monthValue, dayOfMonth)
             monthDays.add(
-                ActiveDayItem(
-                    date = LocalDate.of(yearMonth.year, yearMonth.monthValue, date),
-                    icon = "😂",
-                )
+                ActiveDayItem(date)
             )
         }
 
         // 다음 달 날짜 계산 (남은 공간 채우기)
         val nextMonth = yearMonth.plusMonths(1)
         val remaining = COUNT_OF_ALL_DAYS - monthDays.size
-        for (date in 1..remaining) {
+        for (dayOfMonth in 1..remaining) {
+            val date = LocalDate.of(nextMonth.year, nextMonth.monthValue, dayOfMonth)
             monthDays.add(
-                InactiveDayItem(
-                    date = LocalDate.of(nextMonth.year, nextMonth.monthValue, date),
-                )
+                InactiveDayItem(date)
             )
         }
 

--- a/presentation/src/main/java/kr/co/presentation/ui/preview/DiaryPreviewFactory.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/preview/DiaryPreviewFactory.kt
@@ -1,0 +1,21 @@
+package kr.co.presentation.ui.preview
+
+import kr.co.domain.model.emotion.Emotion
+import kr.co.presentation.ui.model.common.UiDiary
+import kr.co.presentation.viewmodel.diary.DiaryState
+import kr.co.presentation.viewmodel.diary.DiaryUiState
+import java.time.LocalDate
+
+
+object DiaryPreviewFactory {
+    fun createDiaryState(mode: DiaryUiState) = DiaryState(
+        mode = mode,
+        diary = UiDiary(
+            id = 0L,
+            date = LocalDate.now(),
+            title = "어느 화창한 화요일의 기록",
+            content = "오늘은 점심 식사 후 가벼운 산책을 했다. 맑은 하늘과 시원한 바람 덕분에 복잡했던 머릿속이 한결 가벼워지는 기분이었다. 길가에 핀 작은 꽃들을 구경하며 걷다 보니 일상의 소중함을 다시금 느낄 수 있었다. 특별한 일은 없었지만, 이런 평범한 평화가 나를 미소 짓게 한다. 내일도 오늘처럼만 기분 좋은 하루가 되길 바라며 하루를 마무리한다.",
+            emotion = Emotion.SATISFACTION
+        ),
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/MonthlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/MonthlyCalendarScreen.kt
@@ -18,10 +18,12 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,9 +33,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.distinctUntilChanged
+import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
 import kr.co.presentation.ui.component.calendar.CalendarMonth
@@ -44,6 +49,7 @@ import kr.co.presentation.ui.extension.stringArrayResource
 import kr.co.presentation.ui.model.calendar.day.ActiveDayItem
 import kr.co.presentation.ui.model.calendar.day.InactiveDayItem
 import kr.co.presentation.ui.model.calendar.yearmonth.MonthItem
+import kr.co.presentation.ui.model.common.UiDiary
 import kr.co.presentation.ui.preview.CalendarPreviewDataFactory
 import kr.co.presentation.ui.theme.MinaryTheme
 import kr.co.presentation.viewmodel.calendar.MonthlyCalendarIntent
@@ -58,12 +64,12 @@ import java.time.YearMonth
 @Composable
 fun MonthlyCalendarScreen(
     viewModel: MonthlyCalendarViewModel = hiltViewModel(),
-    yearMonth: YearMonth = YearMonth.now(),
     onNavigateToDiaryScreen: (LocalDate) -> Unit,
     onNavigateToYearlyCalendar: (Int) -> Unit = {},
 ) {
     val state by viewModel.collectAsState()
     val pagingItems = viewModel.monthPages.collectAsLazyPagingItems()
+    val diariesMap by viewModel.diariesMap.collectAsState(emptyMap())
     val pagerState = rememberPagerState(
         initialPage = 0,
         pageCount = { pagingItems.itemCount }
@@ -71,18 +77,18 @@ fun MonthlyCalendarScreen(
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
-    val currentVisibleYearMonth by remember {
-        derivedStateOf {
-            if (pagingItems.itemCount > 0 && pagerState.currentPage < pagingItems.itemCount) {
-                pagingItems.peek(pagerState.currentPage)?.yearMonth ?: YearMonth.now()
-            } else {
-                yearMonth
-            }
-        }
-    }
 
-    LaunchedEffect(yearMonth) {
-        viewModel.handleIntent(MonthlyCalendarIntent.UpdateCalendar(yearMonth))
+    LaunchedEffect(pagerState, pagingItems.itemCount) {
+        snapshotFlow { pagerState.currentPage }
+            .distinctUntilChanged()
+            .collect { page ->
+                if (page < pagingItems.itemCount) {
+                    val yearMonth = pagingItems.peek(page)?.yearMonth
+                    yearMonth?.let {
+                        viewModel.handleIntent(MonthlyCalendarIntent.VisibleMonthChanged(it))
+                    }
+                }
+            }
     }
 
     viewModel.collectSideEffect { sideEffect ->
@@ -91,7 +97,7 @@ fun MonthlyCalendarScreen(
                 onNavigateToYearlyCalendar(sideEffect.year)
             }
 
-            is MonthlyCalendarSideEffect.NavigateToDailyCalendar -> {
+            is MonthlyCalendarSideEffect.NavigateToDiaryScreen -> {
                 onNavigateToDiaryScreen(sideEffect.date)
             }
 
@@ -108,10 +114,11 @@ fun MonthlyCalendarScreen(
     }
 
     MonthlyCalendarScreen(
-        yearMonth = currentVisibleYearMonth,
+        yearMonth = state.visibleYearMonth,
         snackbarHostState = snackbarHostState,
         pagingItems = pagingItems,
         pagerState = pagerState,
+        diariesMap = diariesMap,
         intent = viewModel::handleIntent
     )
 }
@@ -125,6 +132,7 @@ private fun MonthlyCalendarScreen(
         initialPage = 0,
         pageCount = { pagingItems.itemCount },
     ),
+    diariesMap: Map<LocalDate, UiDiary> = emptyMap(),
     intent: (MonthlyCalendarIntent) -> Unit = {},
 ) {
     Scaffold(
@@ -150,8 +158,9 @@ private fun MonthlyCalendarScreen(
             CalendarPager(
                 pagerState = pagerState,
                 pagingItems = pagingItems,
-                onDayClick = { date ->
-                    intent(MonthlyCalendarIntent.DayButtonClicked(date))
+                diariesMap = diariesMap,
+                onDayClick = { dayItem ->
+                    intent(MonthlyCalendarIntent.DayClicked(dayItem))
                 }
             )
         }
@@ -221,7 +230,8 @@ private fun Weekday() {
 private fun CalendarPager(
     pagerState: PagerState,
     pagingItems: LazyPagingItems<MonthItem>,
-    onDayClick: (LocalDate) -> Unit = {},
+    diariesMap: Map<LocalDate, UiDiary>,
+    onDayClick: (ActiveDayItem) -> Unit = {},
 ) {
     HorizontalPager(
         state = pagerState,
@@ -247,8 +257,9 @@ private fun CalendarPager(
                         ActiveDay(
                             modifier = Modifier.weight(1f),
                             dayItem,
+                            diary = diariesMap[dayItem.date],
                             isIconVisible = true
-                        ) { date -> onDayClick(date) }
+                        ) { day -> onDayClick(day) }
                     }
 
                     is InactiveDayItem -> {

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/YearlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/contents/calendar/YearlyCalendarScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -38,11 +39,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.distinctUntilChanged
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
 import kr.co.presentation.ui.component.calendar.CalendarMonth
@@ -50,6 +53,7 @@ import kr.co.presentation.ui.component.calendar.day.ActiveDay
 import kr.co.presentation.ui.extension.getString
 import kr.co.presentation.ui.extension.isCurrentMonth
 import kr.co.presentation.ui.extension.isCurrentYear
+import kr.co.presentation.ui.extension.toYearMonth
 import kr.co.presentation.ui.model.calendar.day.ActiveDayItem
 import kr.co.presentation.ui.model.calendar.day.InactiveDayItem
 import kr.co.presentation.ui.model.calendar.yearmonth.MonthItem
@@ -70,7 +74,6 @@ import java.time.YearMonth
 @Composable
 fun YearlyCalendarScreen(
     viewModel: YearlyCalendarViewModel = hiltViewModel(),
-    year: Year = Year.now(),
     onNavigateToMonthlyCalendar: (YearMonth) -> Unit
 ) {
     val state by viewModel.collectAsState()
@@ -82,22 +85,33 @@ fun YearlyCalendarScreen(
     val currentVisibleYear by remember {
         derivedStateOf {
             val visibleItems = gridState.layoutInfo.visibleItemsInfo
-            if (visibleItems.isEmpty()) return@derivedStateOf year
+            if (visibleItems.isEmpty() || pagingItems.itemCount == 0) {
+                return@derivedStateOf state.visibleYear
+            }
 
-            val viewportCenter = gridState.layoutInfo.viewportEndOffset / 2
+            //val viewportCenter = gridState.layoutInfo.viewportEndOffset / 2
+            val viewportCenter = (gridState.layoutInfo.viewportStartOffset + gridState.layoutInfo.viewportEndOffset) / 2
 
             val centralItem = visibleItems.minByOrNull {
-                val itemCenter = (it.offset.y + it.size.height / 2)
+                val itemCenter = it.offset.y + it.size.height / 2
                 kotlin.math.abs(itemCenter - viewportCenter)
             }
 
-            val dataIndex = centralItem?.index ?: 0
-            pagingItems.peek(dataIndex)?.getYear() ?: year
+            centralItem?.index?.let {
+                pagingItems.peek(it)?.getYear()
+            } ?: state.visibleYear
         }
     }
 
-    LaunchedEffect(year) {
-        viewModel.handleIntent(YearlyCalendarIntent.UpdateCalendar(year))
+    LaunchedEffect(gridState, pagingItems.itemCount) {
+        snapshotFlow { gridState.isScrollInProgress }
+            .distinctUntilChanged()
+            .collect { isScrolling ->
+                // 스크롤이 멈췄을 때만
+                if (!isScrolling) {
+                    viewModel.handleIntent(YearlyCalendarIntent.VisibleYearChanged(currentVisibleYear))
+                }
+            }
     }
 
     viewModel.collectSideEffect { sideEffect ->
@@ -115,6 +129,7 @@ fun YearlyCalendarScreen(
             }
         }
     }
+
     YearlyCalendarScreen(
         year = currentVisibleYear,
         pagingItems = pagingItems,
@@ -271,9 +286,8 @@ private fun MonthCalendarItem(
                     modifier = Modifier.weight(1f),
                     dayItem = dayItem,
                     isIconVisible = false
-                ) { date ->
-                    onMonthClick(YearMonth.of(date.year, date.month))
-                    /*onMonthClick(YearMonthItem.MonthItem(year = diary.year, yearMonth = diary.month))*/
+                ) { day ->
+                    onMonthClick(day.toYearMonth())
                 }
             }
 

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/diary/DiaryScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/diary/DiaryScreen.kt
@@ -1,26 +1,236 @@
 package kr.co.presentation.ui.screen.diary
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import kotlinx.coroutines.launch
+import kr.co.domain.model.emotion.Emotion
+import kr.co.presentation.ui.extension.getString
+import kr.co.presentation.ui.extension.color
+import kr.co.presentation.ui.preview.DiaryPreviewFactory
 import kr.co.presentation.ui.theme.MinaryTheme
-import java.time.LocalDate
+import kr.co.presentation.viewmodel.diary.DiaryIntent
+import kr.co.presentation.viewmodel.diary.DiarySideEffect
+import kr.co.presentation.viewmodel.diary.DiaryState
+import kr.co.presentation.viewmodel.diary.DiaryUiState
+import kr.co.presentation.viewmodel.diary.DiaryViewModel
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 
 @Composable
 fun DiaryScreen(
-    date: LocalDate = LocalDate.now(),
-    onNavigateToMainScreen : () -> Unit = {}
+    onNavigateToMainScreen: () -> Unit = {},
+    viewModel: DiaryViewModel = hiltViewModel()
 ) {
-    Text(
-        text = "${date.year}년 ${date.monthValue}월 ${date.dayOfMonth}일",
+    val state: DiaryState by viewModel.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is DiarySideEffect.NavigateToMainScreen -> onNavigateToMainScreen()
+            is DiarySideEffect.ShowMsg -> coroutineScope.launch {
+                snackbarHostState.showSnackbar(context.getString(sideEffect.uiText))
+            }
+        }
+    }
+
+    DiaryScreen(
+        state = state,
+        snackbarHostState = snackbarHostState,
+        intent = viewModel::handleIntent
     )
 }
 
-@Preview(showBackground = true)
 @Composable
-private fun DiaryScreenPreview() {
+private fun DiaryScreen(
+    state: DiaryState = DiaryState(),
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    intent: (DiaryIntent) -> Unit = {}
+) {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            when (state.mode) {
+                DiaryUiState.Edit -> EditTopBar(state.diary.emotion, intent)
+                DiaryUiState.Preview -> PreviewTopBar(state.diary.emotion, intent)
+            }
+        }
+    ) { paddingValues ->
+        val enabled = (state.mode == DiaryUiState.Edit)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = state.diary.date.toString(),
+                fontSize = 20.sp
+            )
+            TextField(
+                value = state.diary.title,
+                onValueChange = { intent(DiaryIntent.TitleChanged(it)) },
+                modifier = Modifier.fillMaxWidth(),
+                enabled = enabled,
+                readOnly = !enabled,
+                singleLine = true,
+                maxLines = 1,
+                label = { Text("Title") },
+                textStyle = TextStyle(
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 24.sp,
+                )
+            )
+            TextField(
+                value = state.diary.content,
+                onValueChange = { intent(DiaryIntent.ContentChanged(it)) },
+                modifier = Modifier.fillMaxSize(),
+                enabled = enabled,
+                readOnly = !enabled,
+                label = { Text("Content") },
+                textStyle = TextStyle(
+                    fontWeight = FontWeight.Normal,
+                    fontSize = 20.sp,
+                )
+            )
+        }
+    }
+}
+
+@Composable
+fun EditTopBar(
+    emotion: Emotion = Emotion.UNKNOWN,
+    intent: (DiaryIntent) -> Unit = {}
+) {
+    Box(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    ) {
+        EmotionIcon(
+            modifier = Modifier.align(Alignment.CenterStart),
+            emotion
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Button(onClick = { intent(DiaryIntent.DoneButtonClicked) }) {
+                Text("Done")
+            }
+        }
+    }
+
+
+}
+
+@Composable
+fun PreviewTopBar(
+    emotion: Emotion = Emotion.UNKNOWN,
+    intent: (DiaryIntent) -> Unit = {}
+) {
+    Box (
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+    ) {
+        EmotionIcon(
+            modifier = Modifier.align(Alignment.CenterStart),
+            emotion
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            var isToggled by rememberSaveable { mutableStateOf(false) }
+
+            IconButton(
+                onClick = {
+                    isToggled = !isToggled
+                    intent(DiaryIntent.DeleteButtonClicked)
+                }
+            ) {
+                Icon(
+                    painter =
+                        if (isToggled) painterResource(android.R.drawable.ic_menu_delete)
+                        else painterResource(android.R.drawable.ic_menu_delete),
+                    contentDescription = if (isToggled) "Selected icon button" else "Unselected icon button."
+                )
+            }
+
+            Button(onClick = { intent(DiaryIntent.EditButtonClicked) }) {
+                Text("Edit")
+            }
+        }
+    }
+}
+
+@Composable
+fun EmotionIcon(
+    modifier: Modifier = Modifier,
+    emotion: Emotion
+) {
+    if (emotion != Emotion.UNKNOWN) {
+        Box(
+            modifier = modifier
+                .size(24.dp)
+                .background(emotion.color, CircleShape)
+        )
+    }
+}
+
+@Preview(showBackground = true, locale = "ko")
+@Composable
+private fun PreviewDiaryScreenPreview() {
+    val diary = DiaryPreviewFactory.createDiaryState(DiaryUiState.Preview)
     MinaryTheme {
-        DiaryScreen()
+        DiaryScreen(diary)
+    }
+}
+
+@Preview(showBackground = true, locale = "ko")
+@Composable
+private fun PreviewDiaryScreenPreview2() {
+    val diary = DiaryPreviewFactory.createDiaryState(DiaryUiState.Edit)
+    MinaryTheme {
+        DiaryScreen(diary)
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/ui/screen/main/MainScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/ui/screen/main/MainScreen.kt
@@ -17,21 +17,28 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import kotlinx.coroutines.launch
 import kr.co.presentation.R
+import kr.co.presentation.ui.extension.getString
 import kr.co.presentation.ui.navigation.extensions.navigateIfNotCurrent
 import kr.co.presentation.ui.navigation.host.MainNavHost
 import kr.co.presentation.ui.navigation.item.NavigationItem
@@ -40,6 +47,11 @@ import kr.co.presentation.ui.navigation.route.DashBoardGraph
 import kr.co.presentation.ui.navigation.route.SettingGraph
 import kr.co.presentation.ui.navigation.route.StoreGraph
 import kr.co.presentation.ui.theme.MinaryTheme
+import kr.co.presentation.viewmodel.main.MainSideEffect
+import kr.co.presentation.viewmodel.main.MainState
+import kr.co.presentation.viewmodel.main.MainViewModel
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 import java.time.LocalDate
 
 
@@ -47,24 +59,41 @@ import java.time.LocalDate
 @Composable
 fun MainScreen(
     onNavigateToDiaryScreen: (LocalDate) -> Unit,
-    // mainViewModel: MainViewModel = hiltViewModel()
+    viewModel: MainViewModel = hiltViewModel()
 ) {
+    val state: MainState by viewModel.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
     val navController = rememberNavController()
 
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is MainSideEffect.NavigateToDiaryScreen -> {
+                onNavigateToDiaryScreen(sideEffect.date)
+            }
+            is MainSideEffect.ShowMsg -> coroutineScope.launch {
+                snackbarHostState.showSnackbar(context.getString(sideEffect.uiText))
+            }
+        }
+    }
+
     MainScreen(
+        snackbarHostState = snackbarHostState,
         navController = navController,
     ) { innerPadding ->
         MainNavHost(
             navController = navController,
             startDestination = CalendarGraph,
             modifier = Modifier.padding(innerPadding),
-            onNavigateToDiaryScreen = onNavigateToDiaryScreen
+            viewModel::handleIntent,
         )
     }
 }
 
 @Composable
 private fun MainScreen(
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     navController: NavHostController = rememberNavController(),
     content: @Composable (PaddingValues) -> Unit = {}
 ) {
@@ -79,6 +108,7 @@ private fun MainScreen(
 
     Scaffold(
         topBar = { TopBar() },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
             BottomAppBar {
                 navigationItems.forEach { item ->

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/auth/LoginViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/auth/LoginViewModel.kt
@@ -4,7 +4,8 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
-import kr.co.domain.usecase.LoginUseCase
+import kr.co.domain.usecase.auth.LoginUseCase
+import kr.co.domain.usecase.diary.CheckAndDownloadInitialDiariesUseCase
 import kr.co.presentation.R
 import kr.co.presentation.ui.model.common.UiText
 import org.orbitmvi.orbit.ContainerHost
@@ -41,6 +42,7 @@ sealed interface LoginIntent {
 @HiltViewModel
 class LoginViewModel @Inject constructor(
     private val loginUseCase: LoginUseCase,
+    private val checkAndDownloadInitialDiariesUseCase: CheckAndDownloadInitialDiariesUseCase,
 ) : ViewModel(), ContainerHost<LoginState, LoginSideEffect> {
 
     override val container = container<LoginState, LoginSideEffect>(LoginState())
@@ -83,6 +85,8 @@ class LoginViewModel @Inject constructor(
 
         val login = loginUseCase(state.id, state.password)
         login.onSuccess {
+            checkAndDownloadInitialDiariesUseCase()
+
             reduce {
                 state.copy(
                     isLoggingIn = false,

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/auth/SignUpViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/auth/SignUpViewModel.kt
@@ -3,7 +3,7 @@ package kr.co.presentation.viewmodel.auth
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
-import kr.co.domain.usecase.SignUpUseCase
+import kr.co.domain.usecase.auth.SignUpUseCase
 import kr.co.presentation.R
 import kr.co.presentation.ui.model.common.UiText
 import org.orbitmvi.orbit.ContainerHost

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/calendar/MonthlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/calendar/MonthlyCalendarViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
@@ -13,10 +14,15 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kr.co.domain.usecase.GetCalendarMonthUseCase
+import kr.co.domain.usecase.calendar.GetCalendarMonthUseCase
+import kr.co.domain.usecase.diary.GetDiariesUseCase
 import kr.co.presentation.mapper.CalendarItemMapper.toMonthItem
+import kr.co.presentation.mapper.UiDiaryMapper.toUiDiary
+import kr.co.presentation.ui.model.calendar.day.ActiveDayItem
 import kr.co.presentation.ui.model.calendar.yearmonth.MonthItem
+import kr.co.presentation.ui.model.common.UiDiary
 import kr.co.presentation.ui.model.common.UiText
+import kr.co.presentation.ui.navigation.route.MonthlyCalendar
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -29,72 +35,131 @@ import javax.inject.Inject
 
 @Immutable
 data class MonthlyCalendarState(
-    val targetYearMonth: YearMonth = YearMonth.now(),
+    val initYearMonth: YearMonth = YearMonth.now(),
     val refreshKey: Long = 0L,
+    val visibleYearMonth: YearMonth = YearMonth.now(),
 )
 
 @Immutable
 sealed interface MonthlyCalendarSideEffect {
     data class NavigateToYearlyCalendar(val year: Int) : MonthlyCalendarSideEffect
-    data class NavigateToDailyCalendar(val date: LocalDate) : MonthlyCalendarSideEffect
+    data class NavigateToDiaryScreen(val date: LocalDate) : MonthlyCalendarSideEffect
     object ScrollToToday : MonthlyCalendarSideEffect
     data class ShowMsg(val uiText: UiText) : MonthlyCalendarSideEffect
 }
 
 sealed interface MonthlyCalendarIntent {
-    data class UpdateCalendar(val targetYearMonth: YearMonth) : MonthlyCalendarIntent
+    data class VisibleMonthChanged(val visibleYearMonth: YearMonth) : MonthlyCalendarIntent
     object TodayButtonClicked : MonthlyCalendarIntent
     data class YearButtonClicked(val year: Int) : MonthlyCalendarIntent
-    data class DayButtonClicked(val date: LocalDate) : MonthlyCalendarIntent
+    data class DayClicked(val dayItem: ActiveDayItem) : MonthlyCalendarIntent
 }
 
 @HiltViewModel
 class MonthlyCalendarViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val getCalendarMonthUseCase: GetCalendarMonthUseCase,
+    private val getDiariesUseCase: GetDiariesUseCase,
 ) : ViewModel(), ContainerHost<MonthlyCalendarState, MonthlyCalendarSideEffect> {
+
+    companion object {
+        private const val KEY_INIT_YEAR = "initYear"
+        private const val KEY_INIT_MONTH = "initMonth"
+        private const val KEY_REFRESH_KEY = "refreshKey"
+
+        private const val KEY_VISIBLE_YEAR = "visibleYear"
+        private const val KEY_VISIBLE_MONTH = "visibleMonth"
+    }
 
     override val container =
         container<MonthlyCalendarState, MonthlyCalendarSideEffect>(MonthlyCalendarState())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val monthPages: Flow<PagingData<MonthItem>> = container.stateFlow
-        .map { state -> (state.targetYearMonth to state.refreshKey) }
+        .map { state -> (state.initYearMonth to state.refreshKey) }
         .distinctUntilChanged()
         .flatMapLatest { (targetYearMonth, refreshKey) ->
-            getCalendarMonthUseCase(targetYearMonth).map { pagingData ->
-                pagingData.map { monthData ->
-                    monthData.toMonthItem()
-                }
+            getCalendarMonthUseCase(targetYearMonth)
+        }.map { pagingData ->
+            pagingData.map { monthData ->
+                monthData.toMonthItem()
             }
         }.cachedIn(viewModelScope)
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val diariesMap: Flow<Map<LocalDate, UiDiary>> = container.stateFlow
+        .map { it.visibleYearMonth }
+        .distinctUntilChanged()
+        .flatMapLatest { yearMonth ->
+            getDiariesUseCase(
+                centerMonth = yearMonth,
+                monthRange = 1
+            )
+        }.map { diaryList ->
+            diaryList.associate { diaryData ->
+                diaryData.date to diaryData.toUiDiary()
+            }
+        }
+
+    init {
+        initializeState()
+    }
+
+    private fun initializeState() = intent {
+        val monthCalender = savedStateHandle.toRoute<MonthlyCalendar>()
+
+        val initYear = savedStateHandle.get<Int>(KEY_INIT_YEAR) ?: monthCalender.year
+        val initMonth = savedStateHandle.get<Int>(KEY_INIT_MONTH) ?: monthCalender.month
+        val refreshKey = savedStateHandle.get<Long>(KEY_REFRESH_KEY) ?: System.currentTimeMillis()
+        val visibleYear = savedStateHandle.get<Int>(KEY_VISIBLE_YEAR) ?: monthCalender.year
+        val visibleMonth = savedStateHandle.get<Int>(KEY_VISIBLE_MONTH) ?: monthCalender.month
+
+        reduce {
+            state.copy(
+                initYearMonth = YearMonth.of(initYear, initMonth),
+                refreshKey = refreshKey,
+                visibleYearMonth = YearMonth.of(visibleYear, visibleMonth)
+            )
+        }
+
+        savedStateHandle[KEY_INIT_YEAR] = initYear
+        savedStateHandle[KEY_INIT_MONTH] = initMonth
+        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
+        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYear
+        savedStateHandle[KEY_VISIBLE_MONTH] = visibleMonth
+    }
+
     fun handleIntent(intent: MonthlyCalendarIntent) {
         when (intent) {
-            is MonthlyCalendarIntent.UpdateCalendar -> updateCalendar(intent.targetYearMonth)
+            is MonthlyCalendarIntent.VisibleMonthChanged -> updateVisibleMonth(intent.visibleYearMonth)
             is MonthlyCalendarIntent.TodayButtonClicked -> scrollToToday()
             is MonthlyCalendarIntent.YearButtonClicked -> navigateToYearlyCalendar(intent.year)
-            is MonthlyCalendarIntent.DayButtonClicked -> navigateToDailyCalendar(intent.date)
+            is MonthlyCalendarIntent.DayClicked -> navigateToDiaryScreen(intent.dayItem.date)
         }
     }
 
-    private fun updateCalendar(targetYearMonth: YearMonth) = intent {
-        reduce {
-            state.copy(
-                targetYearMonth = targetYearMonth,
-                refreshKey = System.currentTimeMillis()
-            )
-        }
+    private fun updateVisibleMonth(visibleYearMonth: YearMonth) = intent {
+        reduce { state.copy(visibleYearMonth = visibleYearMonth) }
+
+        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYearMonth.year
+        savedStateHandle[KEY_VISIBLE_MONTH] = visibleYearMonth.monthValue
     }
 
     private fun scrollToToday() = intent {
-        val today = YearMonth.now()
+        val currentYearMonth = YearMonth.now()
+        val refreshKey = System.currentTimeMillis()
+
         reduce {
             state.copy(
-                targetYearMonth = YearMonth.of(today.year, today.monthValue),
-                refreshKey = System.currentTimeMillis()
+                initYearMonth = currentYearMonth,
+                refreshKey = refreshKey
             )
         }
+
+        savedStateHandle[KEY_INIT_YEAR] = currentYearMonth.year
+        savedStateHandle[KEY_INIT_MONTH] = currentYearMonth.monthValue
+        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
+
         postSideEffect(MonthlyCalendarSideEffect.ScrollToToday)
     }
 
@@ -102,7 +167,7 @@ class MonthlyCalendarViewModel @Inject constructor(
         postSideEffect(MonthlyCalendarSideEffect.NavigateToYearlyCalendar(year))
     }
 
-    private fun navigateToDailyCalendar(date: LocalDate) = intent {
-        postSideEffect(MonthlyCalendarSideEffect.NavigateToDailyCalendar(date))
+    private fun navigateToDiaryScreen(date: LocalDate) = intent {
+        postSideEffect(MonthlyCalendarSideEffect.NavigateToDiaryScreen(date))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/calendar/YearlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/calendar/YearlyCalendarViewModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
@@ -13,12 +14,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
-import kr.co.domain.usecase.GetCalendarYearUseCase
+import kr.co.domain.usecase.calendar.GetCalendarYearUseCase
 import kr.co.presentation.R
 import kr.co.presentation.mapper.CalendarItemMapper.toYearMonthItem
 import kr.co.presentation.ui.extension.isAfterCurrentYearMonth
 import kr.co.presentation.ui.model.calendar.yearmonth.YearMonthItem
 import kr.co.presentation.ui.model.common.UiText
+import kr.co.presentation.ui.navigation.route.YearlyCalender
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -31,8 +33,9 @@ import javax.inject.Inject
 
 @Immutable
 data class YearlyCalendarState(
-    val targetYear: Year = Year.now(),
+    val initYear: Year = Year.now(),
     val refreshKey: Long = 0L,
+    val visibleYear: Year = Year.now(),
 )
 
 @Immutable
@@ -43,7 +46,7 @@ sealed interface YearlyCalendarSideEffect {
 }
 
 sealed interface YearlyCalendarIntent {
-    data class UpdateCalendar(val targetYear: Year) : YearlyCalendarIntent
+    data class VisibleYearChanged(val visibleYear: Year) : YearlyCalendarIntent
     object TodayButtonClicked : YearlyCalendarIntent
     data class MonthButtonClicked(val targetYearMonth: YearMonth) : YearlyCalendarIntent
 }
@@ -54,43 +57,77 @@ class YearlyCalendarViewModel @Inject constructor(
     private val getCalendarYearUseCase: GetCalendarYearUseCase,
 ) : ViewModel(), ContainerHost<YearlyCalendarState, YearlyCalendarSideEffect> {
 
+    companion object {
+        private const val KEY_INIT_YEAR = "initYear"
+        private const val KEY_REFRESH_KEY = "refreshKey"
+        private const val KEY_VISIBLE_YEAR = "visibleYear"
+    }
+
     override val container =
         container<YearlyCalendarState, YearlyCalendarSideEffect>(YearlyCalendarState())
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val yearPages: Flow<PagingData<YearMonthItem>> = container.stateFlow
-        .map { state -> (state.targetYear to state.refreshKey) }
+        .map { state -> (state.initYear to state.refreshKey) }
         .distinctUntilChanged()
         .flatMapLatest { (targetYear, refreshKey) ->
-            getCalendarYearUseCase(targetYear).map { pagingData ->
-                pagingData.map { yearMonthData -> yearMonthData.toYearMonthItem() }
-            }
+            getCalendarYearUseCase(targetYear)
+        }.map { pagingData ->
+            pagingData.map { yearMonthData -> yearMonthData.toYearMonthItem() }
         }.cachedIn(viewModelScope)
+
+    init {
+        initializeState()
+    }
+
+    private fun initializeState() = intent {
+        val yearlyCalender = savedStateHandle.toRoute<YearlyCalender>()
+
+        val initYear = savedStateHandle.get<Int>(KEY_INIT_YEAR) ?: yearlyCalender.year
+        val refreshKey = savedStateHandle.get<Long>(KEY_REFRESH_KEY) ?: System.currentTimeMillis()
+        val visibleYear = savedStateHandle.get<Int>(KEY_VISIBLE_YEAR) ?: yearlyCalender.year
+
+        reduce {
+            state.copy(
+                initYear = Year.of(initYear),
+                refreshKey = refreshKey,
+                visibleYear = Year.of(visibleYear)
+            )
+        }
+
+        savedStateHandle[KEY_INIT_YEAR] = initYear
+        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
+        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYear
+    }
 
     fun handleIntent(intent: YearlyCalendarIntent) {
         when (intent) {
-            is YearlyCalendarIntent.UpdateCalendar -> updateCalendar(intent.targetYear)
+            is YearlyCalendarIntent.VisibleYearChanged -> updateVisibleYear(intent.visibleYear)
             is YearlyCalendarIntent.TodayButtonClicked -> scrollToToday()
             is YearlyCalendarIntent.MonthButtonClicked -> navigateToMonthlyCalendar(intent.targetYearMonth)
         }
     }
 
-    private fun updateCalendar(targetYear: Year) = intent {
-        reduce {
-            state.copy(
-                targetYear = targetYear,
-                refreshKey = System.currentTimeMillis()
-            )
-        }
+    private fun updateVisibleYear(visibleYear: Year) = intent {
+        reduce { state.copy(visibleYear = visibleYear) }
+
+        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYear.value
     }
 
     private fun scrollToToday() = intent {
+        val currentYear = Year.now()
+        val refreshKey = System.currentTimeMillis()
+
         reduce {
             state.copy(
-                targetYear = Year.now(),
-                refreshKey = System.currentTimeMillis()
+                initYear = currentYear,
+                refreshKey = refreshKey
             )
         }
+
+        savedStateHandle[KEY_INIT_YEAR] = currentYear
+        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
+
         postSideEffect(YearlyCalendarSideEffect.ScrollToToday)
     }
 

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/diary/DiaryViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/diary/DiaryViewModel.kt
@@ -1,0 +1,190 @@
+package kr.co.presentation.viewmodel.diary
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kr.co.domain.exception.DiaryNotFoundException
+import kr.co.domain.model.emotion.Emotion
+import kr.co.domain.usecase.diary.DeleteDiaryUseCase
+import kr.co.domain.usecase.diary.GetDiaryUseCase
+import kr.co.domain.usecase.diary.UpsertDiaryUseCase
+import kr.co.presentation.R
+import kr.co.presentation.mapper.UiDiaryMapper.toDiaryData
+import kr.co.presentation.mapper.UiDiaryMapper.toUiDiary
+import kr.co.presentation.ui.model.common.UiDiary
+import kr.co.presentation.ui.model.common.UiText
+import kr.co.presentation.ui.navigation.route.Diary
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import java.time.LocalDate
+import javax.inject.Inject
+
+
+@Immutable
+sealed interface DiaryUiState {
+    object Edit : DiaryUiState
+    object Preview : DiaryUiState
+}
+
+@Immutable
+data class DiaryState(
+    val mode: DiaryUiState = DiaryUiState.Preview,
+    val diary: UiDiary = UiDiary()
+)
+
+@Immutable
+sealed interface DiarySideEffect {
+    object NavigateToMainScreen : DiarySideEffect
+    data class ShowMsg(val uiText: UiText) : DiarySideEffect
+}
+
+sealed interface DiaryIntent {
+    data class TitleChanged(val newTitle: String) : DiaryIntent
+    data class ContentChanged(val newContent: String) : DiaryIntent
+    object DeleteButtonClicked : DiaryIntent
+    object EditButtonClicked : DiaryIntent
+    object DoneButtonClicked : DiaryIntent
+}
+
+@HiltViewModel
+class DiaryViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+    private val getDiaryUseCase: GetDiaryUseCase,
+    private val deleteDiaryUseCase: DeleteDiaryUseCase,
+    private val upsertDiaryUseCase: UpsertDiaryUseCase,
+) : ViewModel(), ContainerHost<DiaryState, DiarySideEffect> {
+
+    companion object {
+        private const val KEY_DIARY_ID = "diary_id"
+        private const val KEY_TITLE = "title"
+        private const val KEY_CONTENT = "content"
+        private const val KEY_EMOTION = "emotion"
+    }
+
+    override val container =
+        container<DiaryState, DiarySideEffect>(DiaryState())
+
+    init {
+         initializeState()
+    }
+
+    private fun initializeState() = intent {
+        val route = savedStateHandle.toRoute<Diary>()
+        val date = LocalDate.of(route.year, route.month, route.date)
+
+        getDiaryUseCase(date).onSuccess { diary ->
+            val uiDiary = diary.toUiDiary()
+            reduce {
+                state.copy(
+                    mode = DiaryUiState.Preview,
+                    diary = uiDiary,
+                )
+            }
+            savedStateHandle[KEY_DIARY_ID] = uiDiary.id
+            savedStateHandle[KEY_TITLE] = uiDiary.title
+            savedStateHandle[KEY_CONTENT] = uiDiary.content
+            savedStateHandle[KEY_EMOTION] = uiDiary.emotion
+        }.onFailure { error ->
+            when (error) {
+                is DiaryNotFoundException -> {
+                    val diaryId = savedStateHandle.get<Long>(KEY_DIARY_ID) ?: 0L
+                    val title = savedStateHandle.get<String>(KEY_TITLE) ?: ""
+                    val content = savedStateHandle.get<String>(KEY_CONTENT) ?: ""
+                    val emotion = savedStateHandle.get<Emotion>(KEY_EMOTION) ?: Emotion.UNKNOWN
+
+                    reduce {
+                        state.copy(
+                            mode = DiaryUiState.Edit,
+                            diary = UiDiary(
+                                id = diaryId,
+                                date = date,
+                                title = title,
+                                content = content,
+                                emotion = emotion,
+                            )
+                        )
+                    }
+                }
+
+                else -> postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
+            }
+        }
+    }
+
+    fun handleIntent(intent: DiaryIntent) {
+        when (intent) {
+            is DiaryIntent.TitleChanged -> updateTitle(intent.newTitle)
+            is DiaryIntent.ContentChanged -> updateContent(intent.newContent)
+            is DiaryIntent.DeleteButtonClicked -> deleteDiary()
+            is DiaryIntent.EditButtonClicked -> changeMode(DiaryUiState.Edit)
+            is DiaryIntent.DoneButtonClicked -> updateDiary()
+        }
+    }
+
+    private fun updateTitle(newTitle: String) = blockingIntent {
+        reduce { state.copy(diary = state.diary.copy(title = newTitle)) }
+        savedStateHandle[KEY_TITLE] = newTitle
+    }
+
+    private fun updateContent(newContent: String) = blockingIntent {
+        reduce { state.copy(diary = state.diary.copy(content = newContent)) }
+        savedStateHandle[KEY_CONTENT] = newContent
+    }
+
+    private fun deleteDiary() = intent {
+        deleteDiaryUseCase(
+            state.diary.toDiaryData()
+        ).onSuccess {
+            postSideEffect(DiarySideEffect.NavigateToMainScreen)
+        }.onFailure { error ->
+            postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
+        }
+    }
+
+    private fun changeMode(mode: DiaryUiState) = intent {
+        reduce { state.copy(mode = mode) }
+    }
+
+    private fun updateDiary() = intent {
+        if (state.diary.title.isNullOrBlank()) {
+            postSideEffect(DiarySideEffect.ShowMsg(UiText.StringResource(R.string.diary_title_is_empty)))
+            return@intent
+        }
+
+        if (state.diary.content.isNullOrBlank()) {
+            postSideEffect(DiarySideEffect.ShowMsg(UiText.StringResource(R.string.diary_content_is_empty)))
+            return@intent
+        }
+
+        upsertDiaryUseCase(
+            state.diary.toDiaryData()
+        ).onSuccess { resultData ->
+            reduce {
+                state.copy(
+                    mode = DiaryUiState.Preview,
+                    diary = state.diary.copy(
+                        id = resultData.id,
+                        emotion = resultData.emotion,
+                    )
+                )
+            }
+            savedStateHandle[KEY_DIARY_ID] = resultData.id
+            savedStateHandle[KEY_EMOTION] = resultData.emotion
+        }.onFailure { error ->
+            postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
+        }
+    }
+
+    private fun handleErrorMsg(error: Throwable): UiText {
+        return error.message
+            .takeIf { !it.isNullOrBlank() }
+            ?.let { UiText.DynamicString(it) }
+            ?: UiText.StringResource(R.string.unknown_error)
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainActivityViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainActivityViewModel.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.exception.AuthException
-import kr.co.domain.model.auth.User
-import kr.co.domain.usecase.IsUserLoggedInUseCase
+import kr.co.domain.usecase.auth.IsUserLoggedInUseCase
+import kr.co.domain.usecase.diary.SyncDiaryUseCase
 import kr.co.presentation.R
 import kr.co.presentation.mapper.UserMapper.toUiUser
-import kr.co.presentation.ui.model.common.UiUser
 import kr.co.presentation.ui.model.common.UiText
+import kr.co.presentation.ui.model.common.UiUser
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -42,7 +42,8 @@ sealed interface MainActivityIntent {
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
-    private val isUserLoggedInUseCase: IsUserLoggedInUseCase
+    private val isUserLoggedInUseCase: IsUserLoggedInUseCase,
+    private val syncDiaryUseCase: SyncDiaryUseCase,
 ) : ViewModel(), ContainerHost<MainActivityState, MainActivitySideEffect> {
 
     override val container = container<MainActivityState, MainActivitySideEffect>(MainActivityState())
@@ -58,6 +59,8 @@ class MainActivityViewModel @Inject constructor(
             reduce {
                 state.copy(loginUser = user.toUiUser(), uiState = MainActivityUiState.Main)
             }
+
+            syncDiaryUseCase()
         }.onFailure { error ->
             reduce {
                 state.copy(loginUser = null, uiState = MainActivityUiState.Auth)

--- a/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/viewmodel/main/MainViewModel.kt
@@ -4,7 +4,10 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.presentation.ui.model.common.UiText
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.viewmodel.container
+import java.time.LocalDate
 import javax.annotation.concurrent.Immutable
 import javax.inject.Inject
 
@@ -16,11 +19,12 @@ data class MainState(
 
 @Immutable
 sealed interface MainSideEffect {
+    data class NavigateToDiaryScreen(val date: LocalDate) : MainSideEffect
     data class ShowMsg(val uiText: UiText) : MainSideEffect
 }
 
 sealed interface MainIntent {
-
+    data class NavigateToDiaryScreen(val date: LocalDate) : MainIntent
 }
 
 @HiltViewModel
@@ -29,4 +33,14 @@ class MainViewModel @Inject constructor(
 ) : ViewModel(), ContainerHost<MainState, MainSideEffect> {
     override val container =
         container<MainState, MainSideEffect>(MainState())
+
+    fun handleIntent(intent: MainIntent) {
+        when (intent) {
+            is MainIntent.NavigateToDiaryScreen -> navigateToPreviewDiaryScreen(intent.date)
+        }
+    }
+
+    private fun navigateToPreviewDiaryScreen(date: LocalDate) = intent {
+        postSideEffect(MainSideEffect.NavigateToDiaryScreen(date))
+    }
 }

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -60,4 +60,46 @@
     <string name="account_creation_failed">계정 생성에 실패했습니다</string>
     <string name="current_user_is_null">없는 사용자입니다</string>
     <string name="preview_mode_main_content_area">메인 화면 (미리보기 화면)</string>
+    <string name="diary_title_is_empty">일기 제목이 비어 있습니다.</string>
+    <string name="diary_content_is_empty">일기 내용이 비어 있습니다</string>
+
+    <!--    감정-->
+    <!--    1. 긍정 & 활력 (Positive & High Energy)-->
+    <string name="emotion_joy">기쁨</string>
+    <string name="emotion_excitement">흥분, 신남</string>
+    <string name="emotion_triumph">승리감</string>
+    <string name="emotion_amusement">즐거움</string>
+    <!--    2. 사랑 & 애정 (Love & Affection)-->
+    <string name="emotion_romance">로맨스</string>
+    <string name="emotion_adoration">흠모</string>
+    <string name="emotion_sexual_desire">성적 욕구</string>
+    <!--    3. 차분함 & 심미 (Calm & Aesthetic)-->
+    <string name="emotion_calmness">차분함</string>
+    <string name="emotion_satisfaction">만족</string>
+    <string name="emotion_aesthetic_appreciation">심미적 감상</string>
+    <string name="emotion_entrancement">황홀경</string>
+    <!--    4. 존경 & 관심 (Respect & Interest)-->
+    <string name="emotion_admiration">존경</string>
+    <string name="emotion_awe">경외감</string>
+    <string name="emotion_interest">흥미, 호기심</string>
+    <!--    5. 슬픔 & 그리움 (Sadness & Longing)-->
+    <string name="emotion_sadness">슬픔</string>
+    <string name="emotion_nostalgia">향수, 그리움</string>
+    <string name="emotion_sympathy">공감</string>
+    <string name="emotion_empathetic_pain">공감적 고통</string>
+    <!--    6. 부정 & 경계 (Negative & Alert)-->
+    <string name="emotion_anger">분노</string>
+    <string name="emotion_fear">두려움</string>
+    <string name="emotion_horror">공포</string>
+    <string name="emotion_anxiety">걱정</string>
+    <!--    7. 복합 & 모호 (Complex & Ambiguous)-->
+    <string name="emotion_confusion">혼란스러움</string>
+    <string name="emotion_boredom">지루함</string>
+    <string name="emotion_awkwardness">어색함</string>
+    <string name="emotion_disgust">역겨움</string>
+    <string name="emotion_envy">부러움, 질투</string>
+    <!--    8. 욕구 (Desire)-->
+    <string name="emotion_craving">간절함</string>
+    <!--    9. 미정 및 기본값 (Undefined / Default)-->
+    <string name="emotion_unknown">알 수 없음</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="month_title">%1$d</string>
     <string name="you_cannot_select_a_date_after_today">You cannot select a date after today</string>
     <string name="welcome">Welcome</string>
-    <string name="your_mind_diary">Your mind diary</string>
+    <string name="your_mind_diary">Your mind diaryData</string>
     <string name="login">Login</string>
     <string name="id">Id</string>
     <string name="user_id">User Id</string>
@@ -60,4 +60,46 @@
     <string name="account_creation_failed">Account creation failed</string>
     <string name="current_user_is_null">Current user is null</string>
     <string name="preview_mode_main_content_area">Main Content Area (Preview Mode)</string>
+    <string name="diary_title_is_empty">diary title is empty</string>
+    <string name="diary_content_is_empty">diary content is empty</string>
+
+    <!--    감정-->
+    <!--    1. 긍정 & 활력 (Positive & High Energy)-->
+    <string name="emotion_joy">joy</string>
+    <string name="emotion_excitement">excitement</string>
+    <string name="emotion_triumph">triumph</string>
+    <string name="emotion_amusement">amusement</string>
+    <!--    2. 사랑 & 애정 (Love & Affection)-->
+    <string name="emotion_romance">romance</string>
+    <string name="emotion_adoration">adoration</string>
+    <string name="emotion_sexual_desire">sexual desire</string>
+    <!--    3. 차분함 & 심미 (Calm & Aesthetic)-->
+    <string name="emotion_calmness">calmness</string>
+    <string name="emotion_satisfaction">satisfaction</string>
+    <string name="emotion_aesthetic_appreciation">aesthetic appreciation</string>
+    <string name="emotion_entrancement">entrancement</string>
+    <!--    4. 존경 & 관심 (Respect & Interest)-->
+    <string name="emotion_admiration">admiration</string>
+    <string name="emotion_awe">awe</string>
+    <string name="emotion_interest">interest</string>
+    <!--    5. 슬픔 & 그리움 (Sadness & Longing)-->
+    <string name="emotion_sadness">sadness</string>
+    <string name="emotion_nostalgia">nostalgia</string>
+    <string name="emotion_sympathy">sympathy</string>
+    <string name="emotion_empathetic_pain">empathetic pain</string>
+    <!--    6. 부정 & 경계 (Negative & Alert)-->
+    <string name="emotion_anger">anger</string>
+    <string name="emotion_fear">fear</string>
+    <string name="emotion_horror">horror</string>
+    <string name="emotion_anxiety">anxiety</string>
+    <!--    7. 복합 & 모호 (Complex & Ambiguous)-->
+    <string name="emotion_confusion">confusion</string>
+    <string name="emotion_boredom">boredom</string>
+    <string name="emotion_awkwardness">awkwardness</string>
+    <string name="emotion_disgust">disgust</string>
+    <string name="emotion_envy">envy</string>
+    <!--    8. 욕구 (Desire)-->
+    <string name="emotion_craving">craving</string>
+    <!--    9. 미정 및 기본값 (Undefined / Default)-->
+    <string name="emotion_unknown">unknown</string>
 </resources>


### PR DESCRIPTION
## 설명
- [Feat] 일기 작성 화면 및 기능 구현

## 관련 이슈
- Closes #8

## 세부 내용
1. 작성, 수정 화면 구현 및 일기 데이터를 로컬 DB(Room)에 저장.
2. 로컬 DB와 Firestore의 일기 데이터를 WorkManager로 동기화 되도록 구현
3. 작성된 일기를 바탕으로 작성자의 감정을 분석할 수 있도록 구현 - Google Generative AI
4. 월간 캘린더 화면에서 작성된 일기 항목이 도트로 표시되도록 구현