### PR TITLE
bug: 연간 캘린더 스크롤시 심하게 렉이 발생하는 부분 수정

### DIFF
--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendar.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendar.kt
@@ -23,7 +23,7 @@ import java.time.YearMonth
 
 
 @Composable
-fun CalendarMonth(
+fun MonthCalendar(
     modifier: Modifier = Modifier,
     monthItem: CalendarMonthItem,
     onClick: ((YearMonth) -> Unit)? = null,
@@ -61,7 +61,7 @@ fun CalendarMonth(
 
 @Preview(showBackground = true, locale = "ko")
 @Composable
-private fun CalendarMonthPreview(
+private fun MonthCalendarPreview(
     @PreviewParameter(CalendarMonthPreviewDataProvider::class) previewData: CalendarMonthPreviewData,
 ) {
     val diary = previewData.emotion?.let {
@@ -69,7 +69,7 @@ private fun CalendarMonthPreview(
     }
 
     MinaryTheme {
-        CalendarMonth(
+        MonthCalendar(
             monthItem = previewData.monthItem,
         ) { dayItem ->
             when (dayItem.isCurrentMonth) {

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendarCanvas.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendarCanvas.kt
@@ -1,0 +1,130 @@
+package kr.co.presentation.feature.calendar.composable
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kr.co.presentation.feature.calendar.extension.isToday
+import kr.co.presentation.feature.calendar.model.CalendarMonthItem
+import kr.co.presentation.feature.calendar.preview.model.CalendarMonthPreviewData
+import kr.co.presentation.feature.calendar.preview.provider.CalendarMonthPreviewDataProvider
+import kr.co.presentation.theme.MinaryTheme
+
+
+@Composable
+fun MonthCalendarCanvas(
+    modifier: Modifier = Modifier,
+    monthItem: CalendarMonthItem,
+    onClick: () -> Unit = {},
+) {
+    val textMeasurer = rememberTextMeasurer()
+
+    val titleStyle = remember {
+        TextStyle(
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.Black,
+            textAlign = TextAlign.Center,
+        )
+    }
+    val sundayStyle = remember {
+        TextStyle(fontSize = 10.sp, color = Color.Red, textAlign = TextAlign.Center)
+    }
+    val dayStyle = remember {
+        TextStyle(fontSize = 10.sp, color = Color.Black, textAlign = TextAlign.Center)
+    }
+    val saturdayStyle = remember {
+        TextStyle(fontSize = 10.sp, color = Color.Blue, textAlign = TextAlign.Center)
+    }
+
+    Canvas(
+        modifier = modifier.then(
+            Modifier
+                .clickable { onClick() } // 월 전체 클릭 이벤트)
+        )
+    ) {
+        val canvasWidth = size.width
+        val canvasHeight = size.height
+        val cellWeight = canvasWidth / 7
+        val paddingTop = 16.dp.toPx()
+
+        val titleLayout = textMeasurer.measure(
+            text = monthItem.yearMonth.monthValue.toString(),
+            style = titleStyle
+        )
+        drawText(
+            textLayoutResult = titleLayout,
+            topLeft = Offset(
+                x = (cellWeight - titleLayout.size.width) / 2,
+                y = paddingTop
+            )
+        )
+
+        val gridStartY = paddingTop + titleLayout.size.height
+
+        monthItem.days.forEachIndexed { index, dayItem ->
+            val row = index / 7
+            val col = index % 7
+
+            val xPos = col * cellWeight
+            val yPos = gridStartY + (row * cellWeight)
+
+            val currentStyle = when (col) {
+                0 -> sundayStyle
+                6 -> saturdayStyle
+                else -> dayStyle
+            }
+            val dayText = when (dayItem.isCurrentMonth) {
+                true -> dayItem.date.dayOfMonth.toString()
+                false -> ""
+            }
+
+            val dayTextLayout = textMeasurer.measure(dayText, currentStyle)
+            drawText(
+                textLayoutResult = dayTextLayout,
+                topLeft = Offset(
+                    x = xPos + (cellWeight - dayTextLayout.size.width) / 2,
+                    y = yPos + (cellWeight - dayTextLayout.size.height) / 2
+                )
+            )
+
+            if (dayItem.isCurrentMonth && dayItem.isToday()) {
+                drawCircle(
+                    color = Color.Blue.copy(alpha = 0.3f),
+                    radius = cellWeight / 2,
+                    center = Offset(x = xPos + cellWeight / 2, y = yPos + cellWeight / 2)
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, locale = "ko")
+@Composable
+private fun MonthCalendarCanvasPreview(
+    @PreviewParameter(CalendarMonthPreviewDataProvider::class) previewData: CalendarMonthPreviewData,
+) {
+    MinaryTheme {
+        MonthCalendarCanvas(
+            modifier = Modifier
+                .aspectRatio(1f)
+                .padding(4.dp),
+            monthItem = previewData.monthItem,
+            onClick = {},
+        )
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/preview/provider/CalendarMonthPreviewDataProvider.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/preview/provider/CalendarMonthPreviewDataProvider.kt
@@ -18,10 +18,6 @@ internal class CalendarMonthPreviewDataProvider(
     override val values: Sequence<CalendarMonthPreviewData> = sequenceOf(
         CalendarMonthPreviewData(
             monthItem = monthItem,
-            emotion = null
-        ),
-        CalendarMonthPreviewData(
-            monthItem = monthItem,
             emotion = Emotion.SADNESS
         )
     )

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
@@ -43,7 +43,7 @@ import kr.co.presentation.R
 import kr.co.presentation.common.composable.stringArrayResource
 import kr.co.presentation.common.extension.getString
 import kr.co.presentation.feature.calendar.composable.ActiveDay
-import kr.co.presentation.feature.calendar.composable.CalendarMonth
+import kr.co.presentation.feature.calendar.composable.MonthCalendar
 import kr.co.presentation.feature.calendar.composable.InactiveDay
 import kr.co.presentation.feature.calendar.model.CalendarDayItem
 import kr.co.presentation.feature.calendar.model.CalendarMonthItem
@@ -244,7 +244,7 @@ private fun CalendarPager(
     ) { page ->
         val monthItem = pagingItems[page]
         monthItem?.let {
-            CalendarMonth(
+            MonthCalendar(
                 monthItem = monthItem,
                 headerContent = {
                     Weekday()

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
@@ -53,7 +53,8 @@ import kotlinx.coroutines.launch
 import kr.co.presentation.R
 import kr.co.presentation.common.extension.getString
 import kr.co.presentation.feature.calendar.composable.ActiveDay
-import kr.co.presentation.feature.calendar.composable.CalendarMonth
+import kr.co.presentation.feature.calendar.composable.MonthCalendar
+import kr.co.presentation.feature.calendar.composable.MonthCalendarCanvas
 import kr.co.presentation.feature.calendar.extension.isCurrentMonth
 import kr.co.presentation.feature.calendar.extension.isCurrentYear
 import kr.co.presentation.feature.calendar.extension.toYearMonth
@@ -290,42 +291,13 @@ private fun MonthCalendarItem(
     monthItem: CalendarMonthItem,
     onMonthClick: (YearMonth) -> Unit = {},
 ) {
-    CalendarMonth(
+    MonthCalendarCanvas(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .padding(4.dp),
         monthItem = monthItem,
-        headerContent = {
-            val isCurrentMonth = monthItem.isCurrentMonth()
-            Text(
-                modifier = Modifier.fillMaxWidth(),
-                text = stringResource(R.string.month_title, monthItem.yearMonth.monthValue),
-                textAlign = TextAlign.Left,
-                color = if (isCurrentMonth) Color.Red else Color.Black,
-                fontWeight = if (isCurrentMonth) FontWeight.Bold else FontWeight.Normal,
-            )
-        },
-        onClick = onMonthClick,
-    ) { dayItem ->
-        when (dayItem.isCurrentMonth) {
-            true -> {
-                ActiveDay(
-                    modifier = Modifier.weight(1f),
-                    dayItem = dayItem,
-                    isIconVisible = false
-                ) { day ->
-                    onMonthClick(day.toYearMonth())
-                }
-            }
-
-            false -> {
-                Spacer(
-                    Modifier
-                        .weight(1f)
-                        .aspectRatio(1f)
-                        .clip(MaterialTheme.shapes.small)
-                        .background(color = Color.Transparent)
-                )
-            }
-        }
-    }
+        onClick = { onMonthClick(monthItem.yearMonth) }
+    )
 }
 
 @Preview(showBackground = true, locale = "ko")


### PR DESCRIPTION
## 설명
- [Bug] 연간 캘린더 스크롤시 심하게 렉이 발생하는 부분 수정

## 관련 이슈
- Closes #33 

## 세부 내용
- 너무 많은 Composable 화면을 그리는 월간 캘린더를 한번에 Canvas로 그리도록 수정
- 추가된 MonthCalendarCanvas와 기존 사용중인 월간 캘린더의 이름을 동일하게 가져가기 위해 수정
- MonthCalendarCanvas의 미리보기 화면을 위해 Preveiw 데이터를 일부 수정