### PR TITLE
refactor: ViewModel에서 프로세스 종료 이후에 값이 유지되도록 savedStateHandle를 사용하도록 수정.

### DIFF
--- a/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/LoginViewModel.kt
@@ -1,13 +1,16 @@
 package kr.co.presentation.feature.auth.viewmodel
 
 import androidx.compose.runtime.Immutable
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.feature.auth.exception.AuthException
 import kr.co.domain.feature.auth.usecase.LoginUseCase
 import kr.co.domain.feature.diary.usecase.CheckAndDownloadInitialDiariesUseCase
 import kr.co.presentation.R
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.feature.auth.navigation.LoginRoute
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -41,11 +44,30 @@ sealed interface LoginIntent {
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
     private val loginUseCase: LoginUseCase,
     private val checkAndDownloadInitialDiariesUseCase: CheckAndDownloadInitialDiariesUseCase,
 ) : ViewModel(), ContainerHost<LoginUiState, LoginSideEffect> {
 
+    companion object {
+        private const val KEY_ID = "user_id"
+        private const val KEY_PASSWORD = "user_password"
+    }
+
     override val container = container<LoginUiState, LoginSideEffect>(LoginUiState())
+
+    init {
+        initializeState()
+    }
+
+    private fun initializeState() = intent {
+        val route = savedStateHandle.toRoute<LoginRoute>()
+
+        val id = savedStateHandle.get<String>(KEY_ID) ?: ""
+        val password = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
+
+        reduce { state.copy(id = id, password = password) }
+    }
 
     fun handleIntent(intent: LoginIntent) {
         when (intent) {
@@ -58,10 +80,12 @@ class LoginViewModel @Inject constructor(
 
     private fun updateId(newId: String) = blockingIntent {
         reduce { state.copy(id = newId) }
+        savedStateHandle[KEY_ID] = newId
     }
 
     private fun updatePassword(newPassword: String) = blockingIntent {
         reduce { state.copy(password = newPassword) }
+        savedStateHandle[KEY_ID] = newPassword
     }
 
     private fun login() = intent {

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/SignUpViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/SignUpViewModel.kt
@@ -1,11 +1,14 @@
 package kr.co.presentation.feature.auth.viewmodel
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.feature.auth.exception.AuthException
 import kr.co.domain.feature.auth.usecase.SignUpUseCase
 import kr.co.presentation.R
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.feature.auth.navigation.SignUpRoute
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -40,10 +43,40 @@ sealed interface SignUpIntent {
 
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
     private val signUpUseCase: SignUpUseCase
 ) : ViewModel(), ContainerHost<SignUpUiState, SignUpSideEffect> {
 
+    companion object {
+        private const val KEY_EMAIL = "email"
+        private const val KEY_USER_NAME = "user_name"
+        private const val KEY_PASSWORD = "password"
+        private const val KEY_CONFIRM_PASSWORD = "confirm_password"
+    }
+
     override val container = container<SignUpUiState, SignUpSideEffect>(SignUpUiState())
+
+    init {
+        initializeState()
+    }
+
+    private fun initializeState() = intent {
+        val route = savedStateHandle.toRoute<SignUpRoute>()
+
+        val email = savedStateHandle.get<String>(KEY_EMAIL) ?: ""
+        val userName = savedStateHandle.get<String>(KEY_USER_NAME) ?: ""
+        val password = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
+        val confirmPassword = savedStateHandle.get<String>(KEY_CONFIRM_PASSWORD) ?: ""
+
+        reduce {
+            state.copy(
+                email = email,
+                userName = userName,
+                password = password,
+                confirmPassword = confirmPassword
+            )
+        }
+    }
 
     fun handelIntent(intent: SignUpIntent) {
         when (intent) {
@@ -57,18 +90,22 @@ class SignUpViewModel @Inject constructor(
 
     private fun updateEmail(newEmail: String) = blockingIntent {
         reduce { state.copy(email = newEmail) }
+        savedStateHandle[KEY_EMAIL] = newEmail
     }
 
     private fun updateUserName(newUserName: String) = blockingIntent {
         reduce { state.copy(userName = newUserName) }
+        savedStateHandle[KEY_USER_NAME] = newUserName
     }
 
     private fun updatePassword(newPassword: String) = blockingIntent {
         reduce { state.copy(password = newPassword) }
+        savedStateHandle[KEY_PASSWORD] = newPassword
     }
 
     private fun updateConfirmPassword(newConfirmPassword: String) = blockingIntent {
         reduce { state.copy(confirmPassword = newConfirmPassword) }
+        savedStateHandle[KEY_CONFIRM_PASSWORD] = newConfirmPassword
     }
 
     private fun signUp() = intent {

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
@@ -43,8 +43,8 @@ import kr.co.presentation.R
 import kr.co.presentation.common.composable.stringArrayResource
 import kr.co.presentation.common.extension.getString
 import kr.co.presentation.feature.calendar.composable.ActiveDay
-import kr.co.presentation.feature.calendar.composable.MonthCalendar
 import kr.co.presentation.feature.calendar.composable.InactiveDay
+import kr.co.presentation.feature.calendar.composable.MonthCalendar
 import kr.co.presentation.feature.calendar.model.CalendarDayItem
 import kr.co.presentation.feature.calendar.model.CalendarMonthItem
 import kr.co.presentation.feature.calendar.preview.provider.MonthlyCalendarPreviewDataProvider

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
@@ -1,11 +1,9 @@
 package kr.co.presentation.feature.calendar.screen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -29,12 +27,10 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
@@ -52,12 +48,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
 import kr.co.presentation.common.extension.getString
-import kr.co.presentation.feature.calendar.composable.ActiveDay
-import kr.co.presentation.feature.calendar.composable.MonthCalendar
 import kr.co.presentation.feature.calendar.composable.MonthCalendarCanvas
-import kr.co.presentation.feature.calendar.extension.isCurrentMonth
 import kr.co.presentation.feature.calendar.extension.isCurrentYear
-import kr.co.presentation.feature.calendar.extension.toYearMonth
 import kr.co.presentation.feature.calendar.model.CalendarGridItem
 import kr.co.presentation.feature.calendar.model.CalendarMonthItem
 import kr.co.presentation.feature.calendar.model.CalendarYearItem

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/MonthlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/MonthlyCalendarViewModel.kt
@@ -121,12 +121,6 @@ class MonthlyCalendarViewModel @Inject constructor(
                 visibleYearMonth = YearMonth.of(visibleYear, visibleMonth)
             )
         }
-
-        savedStateHandle[KEY_INIT_YEAR] = initYear
-        savedStateHandle[KEY_INIT_MONTH] = initMonth
-        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
-        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYear
-        savedStateHandle[KEY_VISIBLE_MONTH] = visibleMonth
     }
 
     fun handleIntent(intent: MonthlyCalendarIntent) {

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/YearlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/YearlyCalendarViewModel.kt
@@ -108,10 +108,6 @@ class YearlyCalendarViewModel @Inject constructor(
             postSideEffect(YearlyCalendarSideEffect.ScrollToInitialPosition)
             savedStateHandle[KEY_INITIAL_SCROLL_COMPLETED] = true
         }
-
-        savedStateHandle[KEY_INIT_YEAR] = initYear
-        savedStateHandle[KEY_REFRESH_KEY] = refreshKey
-        savedStateHandle[KEY_VISIBLE_YEAR] = visibleYear
     }
 
     fun handleIntent(intent: YearlyCalendarIntent) {

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/viewmodel/DiaryViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/viewmodel/DiaryViewModel.kt
@@ -66,7 +66,7 @@ class DiaryViewModel @Inject constructor(
     companion object {
         private const val KEY_SCREEN_MODE = "screen_mode"
         private const val KEY_DIARY_ID = "diary_id"
-        private const val KEY_TITLE = "title"
+        private const val KEY_PASSWORD = "title"
         private const val KEY_CONTENT = "content"
         private const val KEY_EMOTION = "emotion"
     }
@@ -75,12 +75,18 @@ class DiaryViewModel @Inject constructor(
         container<DiaryUiState, DiarySideEffect>(DiaryUiState())
 
     init {
-         initializeState()
+        initializeState()
     }
 
     private fun initializeState() = intent {
         val route = savedStateHandle.toRoute<DiaryRoute>()
         val date = LocalDate.of(route.year, route.month, route.date)
+
+        val screenMode = savedStateHandle.get<DiaryScreenMode>(KEY_SCREEN_MODE) ?: DiaryScreenMode.Edit
+        val diaryId = savedStateHandle.get<Long>(KEY_DIARY_ID) ?: 0L
+        val title = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
+        val content = savedStateHandle.get<String>(KEY_CONTENT) ?: ""
+        val emotion = savedStateHandle.get<Emotion>(KEY_EMOTION) ?: Emotion.UNKNOWN
 
         getDiaryUseCase(date).onSuccess { diary ->
             val diaryUiModel = diary.toDiaryUiModel()
@@ -93,18 +99,12 @@ class DiaryViewModel @Inject constructor(
             }
             savedStateHandle[KEY_SCREEN_MODE] = screenMode
             savedStateHandle[KEY_DIARY_ID] = diaryUiModel.id
-            savedStateHandle[KEY_TITLE] = diaryUiModel.title
+            savedStateHandle[KEY_PASSWORD] = diaryUiModel.title
             savedStateHandle[KEY_CONTENT] = diaryUiModel.content
             savedStateHandle[KEY_EMOTION] = diaryUiModel.emotion
         }.onFailure { error ->
             when (error) {
                 is DiaryNotFoundException -> {
-                    val screenMode = savedStateHandle.get<DiaryScreenMode>(KEY_SCREEN_MODE) ?: DiaryScreenMode.Edit
-                    val diaryId = savedStateHandle.get<Long>(KEY_DIARY_ID) ?: 0L
-                    val title = savedStateHandle.get<String>(KEY_TITLE) ?: ""
-                    val content = savedStateHandle.get<String>(KEY_CONTENT) ?: ""
-                    val emotion = savedStateHandle.get<Emotion>(KEY_EMOTION) ?: Emotion.UNKNOWN
-
                     reduce {
                         state.copy(
                             screenMode = screenMode,
@@ -136,7 +136,7 @@ class DiaryViewModel @Inject constructor(
 
     private fun updateTitle(newTitle: String) = blockingIntent {
         reduce { state.copy(diaryUiModel = state.diaryUiModel.copy(title = newTitle)) }
-        savedStateHandle[KEY_TITLE] = newTitle
+        savedStateHandle[KEY_PASSWORD] = newTitle
     }
 
     private fun updateContent(newContent: String) = blockingIntent {
@@ -183,7 +183,7 @@ class DiaryViewModel @Inject constructor(
             }
             savedStateHandle[KEY_SCREEN_MODE] = screenMode
             savedStateHandle[KEY_DIARY_ID] = diaryUiModel.id
-            savedStateHandle[KEY_TITLE] = diaryUiModel.title
+            savedStateHandle[KEY_PASSWORD] = diaryUiModel.title
             savedStateHandle[KEY_CONTENT] = diaryUiModel.content
             savedStateHandle[KEY_EMOTION] = diaryUiModel.emotion
         }.onFailure { error ->

--- a/presentation/src/main/java/kr/co/presentation/main/screen/MainActivity.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/screen/MainActivity.kt
@@ -17,8 +17,8 @@ import kr.co.presentation.common.extension.getString
 import kr.co.presentation.feature.auth.navigation.WelcomeRoute
 import kr.co.presentation.main.navigation.MainRoute
 import kr.co.presentation.main.viewmodel.MainActivitySideEffect
-import kr.co.presentation.main.viewmodel.StartDestination
 import kr.co.presentation.main.viewmodel.MainActivityViewModel
+import kr.co.presentation.main.viewmodel.StartDestination
 import kr.co.presentation.navigation.host.AppNaveGraph
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState

--- a/presentation/src/main/java/kr/co/presentation/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/screen/MainScreen.kt
@@ -46,11 +46,9 @@ import kr.co.presentation.feature.store.navigation.StoreRoute
 import kr.co.presentation.main.navigation.MainHost
 import kr.co.presentation.main.navigation.MainNavigationItem
 import kr.co.presentation.main.viewmodel.MainSideEffect
-import kr.co.presentation.main.viewmodel.MainUiState
 import kr.co.presentation.main.viewmodel.MainViewModel
 import kr.co.presentation.navigation.extension.navigateIfNotCurrent
 import kr.co.presentation.theme.MinaryTheme
-import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 import java.time.LocalDate
 import java.time.YearMonth
@@ -62,7 +60,6 @@ fun MainScreen(
     onNavigateToDiaryScreen: (LocalDate) -> Unit,
     viewModel: MainViewModel = hiltViewModel()
 ) {
-    val state: MainUiState by viewModel.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current

--- a/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainActivityViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainActivityViewModel.kt
@@ -36,10 +36,6 @@ sealed interface MainActivitySideEffect {
     data class ShowMsg(val uiText: UiText) : MainActivitySideEffect // 오류 메시지 표시
 }
 
-sealed interface MainActivityIntent {
-
-}
-
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val isUserLoggedInUseCase: IsUserLoggedInUseCase,

--- a/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainViewModel.kt
@@ -13,11 +13,6 @@ import javax.inject.Inject
 
 
 @Immutable
-data class MainUiState(
-    val selectedItem: String = ""
-)
-
-@Immutable
 sealed interface MainSideEffect {
     data class NavigateToDiaryScreen(val date: LocalDate) : MainSideEffect
     data class ShowMsg(val uiText: UiText) : MainSideEffect
@@ -29,10 +24,10 @@ sealed interface MainIntent {
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+) : ViewModel(), ContainerHost<Unit, MainSideEffect> {
+    override val container = container<Unit, MainSideEffect>(Unit)
 
-) : ViewModel(), ContainerHost<MainUiState, MainSideEffect> {
-    override val container =
-        container<MainUiState, MainSideEffect>(MainUiState())
+    companion object {}
 
     fun handleIntent(intent: MainIntent) {
         when (intent) {


### PR DESCRIPTION
## 설명
- [Refactor] ViewModel에서 프로세스 종료 이후에 값이 유지되도록 savedStateHandle를 적용

## 관련 이슈
- Closes #30 

## 세부 내용
- 프로세스 종료 이후에도 사용자가 동일한 환경에서 다시 작업 할 수 있도록 VeiwModel에서 savedStateHandle적용