### PR TITLE
feat: 네트워크 통신, 로컬 DB 연동으로 데이터 로드 중 일 때. 스켈레톤 화면 표시 및 버튼 로딩기능 추가

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.0"
+agp = "9.0.1"
 coreSplashscreen = "1.0.1"
 datastorePreferences = "1.1.4"
 firebaseBom = "33.13.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Mar 28 17:58:12 KST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/presentation/src/main/java/kr/co/presentation/common/composable/LoadStateContent.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/composable/LoadStateContent.kt
@@ -1,0 +1,21 @@
+package kr.co.presentation.common.composable
+
+import androidx.compose.runtime.Composable
+import kr.co.presentation.common.state.LoadState
+
+
+@Composable
+fun <T> LoadStateContent(
+    loadState: LoadState<T>,
+    uninitialized: @Composable () -> Unit = {},
+    loading: @Composable () -> Unit = {},
+    error: @Composable (Throwable?) -> Unit = {},
+    content: @Composable (T) -> Unit
+) {
+    when (loadState) {
+        is LoadState.Uninitialized -> uninitialized()
+        is LoadState.Loading -> loading()
+        is LoadState.Error -> error(loadState.exception)
+        is LoadState.Success -> content(loadState.data)
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/common/composable/LoadingButton.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/composable/LoadingButton.kt
@@ -1,0 +1,74 @@
+package kr.co.presentation.common.composable
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.co.presentation.theme.MinaryTheme
+
+
+@Composable
+fun LoadingButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = true,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled && !isLoading,
+        colors = ButtonDefaults.buttonColors()
+    ) {
+        Box {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .align(Alignment.Center),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 3.dp
+                )
+            }
+
+            Text(
+                text = text,
+                color = if (isLoading) Color.Transparent else MaterialTheme.colorScheme.onPrimary
+            )
+        }
+    }
+}
+
+@Preview(name = "LoadingButton", showBackground = true)
+@Composable
+private fun LoadingButtonNotLoadingPreview() {
+    MinaryTheme {
+        LoadingButton(
+            text = "Loading Button",
+            onClick = { },
+            isLoading = false,
+        )
+    }
+}
+
+@Preview(name = "LoadingButton - Loading", showBackground = true)
+@Composable
+private fun LoadingButtonLoadingPreview() {
+    MinaryTheme {
+        LoadingButton(
+            text = "Loading Button",
+            onClick = { },
+            isLoading = true,
+        )
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/common/composable/LoadingIconButton.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/composable/LoadingIconButton.kt
@@ -1,0 +1,80 @@
+package kr.co.presentation.common.composable
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.co.presentation.theme.MinaryTheme
+
+
+@Composable
+fun LoadingIconButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = true,
+    iconContent: @Composable (Boolean) -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled && !isLoading,
+        colors = IconButtonDefaults.iconButtonColors(),
+    ) {
+        Box {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    strokeWidth = 3.dp
+                )
+            }
+            iconContent(isLoading)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingIconButtonNotLoadingPreview() {
+    MinaryTheme {
+        LoadingIconButton(
+            onClick = { },
+            isLoading = false,
+        ) { isLoading ->
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "add",
+                tint = if (isLoading) Color.Transparent else LocalContentColor.current,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun LoadingIconButtonLoadingPreview() {
+    MinaryTheme {
+        LoadingIconButton(
+            onClick = { },
+            isLoading = true,
+        ) { isLoading ->
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = "add",
+                tint = if (isLoading) Color.Transparent else LocalContentColor.current,
+            )
+        }
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/common/extension/ModifierExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/extension/ModifierExtensions.kt
@@ -1,0 +1,54 @@
+package kr.co.presentation.common.extension
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+
+
+/**
+ * Composable의 배경에 Shimmer 애니메이션을 적용합니다.
+ * 스켈레톤 UI(Skeleton UI)의 배경을 표현할 때 유용합니다.
+ */
+fun Modifier.shimmerBackground(): Modifier = composed {
+    // 1. 무한 반복되는 애니메이션 설정
+    val transition = rememberInfiniteTransition(label = "shimmer")
+    // 2. X축 좌표 이동 애니메이션 (왼쪽 끝 -> 오른쪽 끝)
+    val translateAnimation by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 2000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = 1000,
+                easing = FastOutSlowInEasing
+            ),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "shimmerTranslate"
+    )
+
+    // 3. 그라데이션 브러쉬 생성 (어두운 회색 -> 밝은 회색 -> 어두운 회색)
+    val shimmerColors = listOf(
+        Color.LightGray.copy(alpha = 0.6f),
+        Color.LightGray.copy(alpha = 0.4f),
+        Color.LightGray.copy(alpha = 0.6f),
+    )
+
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset.Zero,
+        end = Offset(x = translateAnimation, y = translateAnimation)
+    )
+
+    // 4. 배경으로 적용
+    this.background(brush)
+}

--- a/presentation/src/main/java/kr/co/presentation/common/extension/OrbitExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/extension/OrbitExtensions.kt
@@ -1,0 +1,171 @@
+package kr.co.presentation.common.extension
+
+import androidx.annotation.CheckResult
+import kotlinx.coroutines.CancellationException
+import kr.co.presentation.common.state.LoadState
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
+
+/**
+ * Orbit MVI의 `SimpleSyntax` 내에서 안전한 비동기 작업을 시작하기 위한 확장 함수입니다.
+ * `Result`를 반환하는 `action`을 받아, 체이닝 가능한 `OrbitCall`를 생성합니다.
+ *
+ * @param STATE Orbit의 State 타입
+ * @param SIDE_EFFECT Orbit의 SideEffect 타입
+ * @param T `action`이 성공했을 때 반환하는 데이터의 타입
+ * @param action 비동기적으로 실행될 작업으로, `Result<T>`를 반환해야 합니다.
+ * @return `OrbitCall` 인스턴스
+ */
+@CheckResult(suggest = "launchOnSuccess 또는 launchAsLoadState 호출하여 작업을 완료해야 합니다.")
+fun <STATE : Any, SIDE_EFFECT : Any, T : Any> SimpleSyntax<STATE, SIDE_EFFECT>.safeCall(
+    action: suspend () -> Result<T>
+): OrbitCall<STATE, SIDE_EFFECT, T, T> {
+    return OrbitCall(this, action) { it }
+}
+
+/**
+ * Orbit MVI의 비동기 작업을 위한 빌더 클래스입니다.
+ * 로딩, 성공, 실패 상태를 관리하며, `onStart`, `onFinally`, `onError`, `onLoading`과 같은 콜백을 체이닝 방식으로 구성할 수 있습니다.
+ * 작업 실행을 위해서는 반드시 `launchAsLoadState` 또는 `launchOnSuccess`와 같은 종단 연산자를 호출해야 합니다.
+ */
+class OrbitCall<STATE : Any, SIDE_EFFECT : Any, T : Any, R : Any>(
+    private val syntax: SimpleSyntax<STATE, SIDE_EFFECT>,
+    private val action: suspend () -> Result<T>,
+    private val mapper: suspend (T) -> R
+) {
+    private var onStartBlock: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
+    private var onFinallyBlock: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit)? = null
+    private var onLoadingBlock: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.(Boolean) -> Unit)? = null
+    private var onErrorBlock: (suspend SimpleSyntax<STATE, SIDE_EFFECT>.(Throwable) -> Unit)? = null
+
+    /**
+     * 작업 성공 시의 결과를 다른 타입으로 변환합니다.
+     * 이 함수를 사용한 후에도 반드시 종단 연산자를 호출해야 합니다.
+     *
+     * @param newMapper `R` 타입을 `NEW_R` 타입으로 변환하는 매퍼 함수
+     * @return 새로운 결과 타입을 가진 `OrbitCall` 인스턴스
+     */
+    @CheckResult
+    fun <NEW_R : Any> map(newMapper: suspend (R) -> NEW_R): OrbitCall<STATE, SIDE_EFFECT, T, NEW_R> {
+        return OrbitCall(syntax, action) { result ->
+            newMapper(mapper(result))
+        }.also { newBuilder ->
+            // 상태 복사
+            newBuilder.onStartBlock = this.onStartBlock
+            newBuilder.onFinallyBlock = this.onFinallyBlock
+            newBuilder.onErrorBlock = this.onErrorBlock
+            newBuilder.onLoadingBlock = this.onLoadingBlock
+        }
+    }
+
+    /**
+     * 작업이 시작될 때 호출될 콜백을 등록합니다.
+     * 이 함수를 사용한 후에도 반드시 종단 연산자를 호출해야 합니다.
+     */
+    @CheckResult
+    fun onStart(block: suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit) = apply {
+        val oldBlock = this.onStartBlock
+        this.onStartBlock = if (oldBlock == null) block else {
+            { oldBlock(); block() }
+        }
+    }
+
+    /**
+     * 작업이 성공 또는 실패로 완료된 후 항상 호출될 콜백을 등록합니다.
+     * 이 함수를 사용한 후에도 반드시 종단 연산자를 호출해야 합니다.
+     */
+    @CheckResult
+    fun onFinally(block: suspend SimpleSyntax<STATE, SIDE_EFFECT>.() -> Unit) = apply {
+        val oldBlock = this.onFinallyBlock
+        this.onFinallyBlock = if (oldBlock == null) block else {
+            { oldBlock(); block() }
+        }
+    }
+
+    /**
+     * 작업의 로딩 상태가 변경될 때 호출될 콜백을 등록합니다.
+     * 종단 연산자에서 작업이 시작될 때 `true`, 작업이 완료(성공/실패)될 때 `false`를 전달받습니다.
+     * 이 함수를 사용한 후에도 반드시 종단 연산자를 호출해야 합니다.
+     */
+    @CheckResult
+    fun onLoading(block: suspend SimpleSyntax<STATE, SIDE_EFFECT>.(isLoading: Boolean) -> Unit) = apply {
+        val oldBlock = this.onLoadingBlock
+        this.onLoadingBlock =
+            if (oldBlock == null) block else { isLoading -> oldBlock(isLoading); block(isLoading) }
+    }
+
+    /**
+     * 작업이 실패했을 때 호출될 콜백을 등록합니다.
+     * 이 함수를 사용한 후에도 반드시 종단 연산자를 호출해야 합니다.
+     */
+    @CheckResult
+    fun onError(block: suspend SimpleSyntax<STATE, SIDE_EFFECT>.(error: Throwable) -> Unit) = apply {
+        val oldBlock = this.onErrorBlock
+        this.onErrorBlock =
+            if (oldBlock == null) block else { error -> oldBlock(error); block(error) }
+    }
+
+    /**
+     * [종단 연산자]
+     * 이 함수를 호출해야 요청이 실행되고 결과가 `LoadState`로 반영됩니다.
+     *
+     * @param onLoadStateBlock `LoadState` 변경을 처리할 콜백
+     */
+    suspend fun launchAsLoadState(
+        onLoadStateBlock: suspend SimpleSyntax<STATE, SIDE_EFFECT>.(loadState: LoadState<R>) -> Unit
+    ) {
+        with(syntax) {
+            onStartBlock?.invoke(this) // onStart 실행
+            onLoadingBlock?.invoke(this, true)
+            onLoadStateBlock(LoadState.Loading)
+
+            executeAction()
+                .fold(
+                    onSuccess = { data -> onLoadStateBlock(LoadState.Success(data)) },
+                    onFailure = { error ->
+                        onLoadStateBlock(LoadState.Error(error))
+                        onErrorBlock?.invoke(this, error) // onError 실행
+                    }
+                )
+
+            onLoadingBlock?.invoke(this, false)
+            onFinallyBlock?.invoke(this) // onFinally 실행
+        }
+    }
+
+    /**
+     * [종단 연산자]
+     * 이 함수를 호출해야 요청이 실행되고 성공 시의 결과만 처리됩니다.
+     *
+     * @param onSuccessBlock 작업 성공 시 호출될 콜백
+     */
+    suspend fun launchOnSuccess(
+        onSuccessBlock: suspend SimpleSyntax<STATE, SIDE_EFFECT>.(R) -> Unit
+    ) {
+        with(syntax) {
+            onStartBlock?.invoke(this)
+            onLoadingBlock?.invoke(this, true)
+
+            executeAction()
+                .fold(
+                    onSuccess = { data -> onSuccessBlock(data) },
+                    onFailure = { error -> onErrorBlock?.invoke(this, error) }
+                )
+
+            onLoadingBlock?.invoke(this, false)
+            onFinallyBlock?.invoke(this)
+        }
+    }
+
+    private suspend fun executeAction(): Result<R> {
+        return try {
+            action().mapCatching { mapper(it) }
+        } catch (error: CancellationException) {
+            // 코루틴의 협력적 취소를 지원하기 위해 CancellationException은 잡은 후 다시 던집니다.
+            // 이 예외를 무시하면 코루틴이 취소되었을 때 상위 코루틴으로 전파되지 않아,
+            // 원하지 않는 동작이나 리소스 누수를 유발할 수 있습니다.
+            throw error
+        } catch (error: Exception) {
+            Result.failure(error)
+        }
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/common/extension/SavedStateHandleExtensions.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/extension/SavedStateHandleExtensions.kt
@@ -1,0 +1,49 @@
+package kr.co.presentation.common.extension
+
+import androidx.lifecycle.SavedStateHandle
+import java.time.LocalDate
+
+
+/**
+ * SavedStateHandle에서 Key에 해당하는 값을 안전하게 Long 타입으로 반환합니다.
+ * 내부적으로 Integer로 저장되었더라도 Long으로 변환해줍니다.
+ * 값이 없거나 타입이 맞지 않으면 null을 반환합니다.
+ */
+fun SavedStateHandle.getLong(key: String): Long? {
+    return (this[key] as? Number)?.toLong()
+}
+
+/**
+ * SavedStateHandle에서 Key에 해당하는 값을 안전하게 Long 타입으로 반환합니다.
+ * 내부적으로 Integer로 저장되었더라도 Long으로 변환해줍니다.
+ * 값이 없거나 타입이 맞지 않으면 defaultValue를 반환합니다.
+ */
+fun SavedStateHandle.getLong(key: String, defaultValue: Long): Long {
+    return (this[key] as? Number)?.toLong() ?: defaultValue
+}
+
+/**
+ * SavedStateHandle에서 Key에 해당하는 epochDay 값을 안전하게 LocalDate 타입으로 반환합니다.
+ * 값이 없거나 타입이 맞지 않으면 null을 반환합니다.
+ */
+fun SavedStateHandle.getLocalDate(key: String): LocalDate? {
+    val epochDay = (this[key] as? Number)?.toLong()
+    return if (epochDay != null) {
+        LocalDate.ofEpochDay(epochDay)
+    } else {
+        null
+    }
+}
+
+/**
+ * SavedStateHandle에서 Key에 해당하는 epochDay 값을 안전하게 LocalDate 타입으로 반환합니다.
+ * 값이 없거나 타입이 맞지 않으면 defaultValue를 반환합니다.
+ */
+fun SavedStateHandle.getLocalDate(key: String, defaultValue: LocalDate): LocalDate {
+    val epochDay = (this[key] as? Number)?.toLong()
+    return if (epochDay != null) {
+        LocalDate.ofEpochDay(epochDay)
+    } else {
+        defaultValue
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonButton.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonButton.kt
@@ -1,0 +1,33 @@
+package kr.co.presentation.common.skeleton
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import kr.co.presentation.common.extension.shimmerBackground
+
+
+@Composable
+fun SkeletonButton(
+    modifier: Modifier = Modifier,
+    shape: Shape = ButtonDefaults.shape,
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        modifier = modifier
+            .clearAndSetSemantics{}
+            .clip(shape) // 버튼 쉐이프 (RoundedCornerShape 등)
+            .shimmerBackground(), // ✨ 버튼 전체 배경이 반짝이게 하거나,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = Color.Transparent,
+            contentColor = Color.Transparent
+        ),
+        onClick = {},
+        content = content
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonIcon.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonIcon.kt
@@ -1,0 +1,32 @@
+package kr.co.presentation.common.skeleton
+
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import kr.co.presentation.common.extension.shimmerBackground
+
+
+@Composable
+fun SkeletonIconButton(
+    modifier: Modifier = Modifier,
+    shape: Shape = IconButtonDefaults.filledShape,
+    content: @Composable () -> Unit,
+) {
+    IconButton(
+        modifier = modifier
+            .clearAndSetSemantics {}
+            .clip(shape)
+            .shimmerBackground(),
+        colors = IconButtonDefaults.iconButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = Color.Transparent
+        ),
+        onClick = { },
+        content = content,
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonSpacer.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonSpacer.kt
@@ -1,0 +1,25 @@
+package kr.co.presentation.common.skeleton
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.dp
+import kr.co.presentation.common.extension.shimmerBackground
+
+
+@Composable
+fun SkeletonSpacer(
+    modifier: Modifier = Modifier,
+    shape: Shape = RoundedCornerShape(4.dp)
+) {
+    Spacer(
+        modifier = modifier
+            .clearAndSetSemantics {}
+            .clip(shape)
+            .shimmerBackground(),
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonText.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/skeleton/SkeletonText.kt
@@ -1,0 +1,48 @@
+package kr.co.presentation.common.skeleton
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
+import kr.co.presentation.common.extension.shimmerBackground
+
+
+@Composable
+fun SkeletonText(
+    modifier: Modifier = Modifier,
+    text: String,
+    shape: Shape = RoundedCornerShape(4.dp),
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily? = null,
+    textAlign: TextAlign? = null,
+    style: TextStyle = LocalTextStyle.current,
+) {
+    Text(
+        text = text,
+        modifier = modifier
+            .clearAndSetSemantics {}
+            .clip(shape)
+            .shimmerBackground(),
+        color = Color.Transparent,
+        style = style,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        textAlign = textAlign,
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/common/state/LoadState.kt
+++ b/presentation/src/main/java/kr/co/presentation/common/state/LoadState.kt
@@ -1,0 +1,26 @@
+package kr.co.presentation.common.state
+
+import androidx.compose.runtime.Immutable
+
+
+@Immutable
+sealed interface LoadState<out T> {
+    data object Uninitialized : LoadState<Nothing>
+    data object Loading : LoadState<Nothing>
+    data class Success<T>(val data: T) : LoadState<T>
+    data class Error(
+        val exception: Throwable? = null,
+        val message: String? = null
+    ) : LoadState<Nothing>
+
+    val isUninitialized: Boolean get() = this is Uninitialized
+    val isLoading: Boolean get() = this is Loading
+    val isSuccess: Boolean get() = this is Success
+    val isError: Boolean get() = this is Error
+}
+
+/**
+ * UiState가 Success 상태일 경우 데이터를 반환하고, 그렇지 않으면 null 반환합니다.
+ */
+val <T> LoadState<T>.data: T?
+    get() = (this as? LoadState.Success)?.data

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/preview/provider/LoginPreviewDataProvider.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/preview/provider/LoginPreviewDataProvider.kt
@@ -1,0 +1,14 @@
+package kr.co.presentation.feature.auth.preview.provider
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import kr.co.presentation.common.state.LoadState
+import kr.co.presentation.feature.auth.viewmodel.LoginScreenState
+
+
+internal class LoginPreviewDataProvider : PreviewParameterProvider<LoginScreenState> {
+
+    override val values: Sequence<LoginScreenState> = sequenceOf(
+        LoginScreenState(email = "testEmail", password = "testPassword"),
+        LoginScreenState(email = "testEmail", password = "testPassword", loginLoadState = LoadState.Loading),
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/preview/provider/SignUpPreviewDataProvider.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/preview/provider/SignUpPreviewDataProvider.kt
@@ -1,0 +1,26 @@
+package kr.co.presentation.feature.auth.preview.provider
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import kr.co.presentation.common.state.LoadState
+import kr.co.presentation.feature.auth.viewmodel.SignUpScreenState
+
+
+internal class SignUpPreviewDataProvider : PreviewParameterProvider<SignUpScreenState> {
+
+    override val values: Sequence<SignUpScreenState> = sequenceOf(
+        SignUpScreenState(
+            signUpLoadState = LoadState.Uninitialized,
+            email = "testEmail",
+            name = "testName",
+            password = "testPw",
+            confirmPassword = "testConfirmPw"
+        ),
+        SignUpScreenState(
+            signUpLoadState = LoadState.Loading,
+            email = "testEmail",
+            name = "testName",
+            password = "testPw",
+            confirmPassword = "testConfirmPw"
+        ),
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/screen/LoginScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/screen/LoginScreen.kt
@@ -1,20 +1,12 @@
 package kr.co.presentation.feature.auth.screen
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -27,21 +19,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
+import kr.co.presentation.common.composable.LoadingButton
 import kr.co.presentation.common.extension.getString
-import kr.co.presentation.theme.MinaryTheme
+import kr.co.presentation.feature.auth.preview.provider.LoginPreviewDataProvider
 import kr.co.presentation.feature.auth.viewmodel.LoginIntent
 import kr.co.presentation.feature.auth.viewmodel.LoginSideEffect
-import kr.co.presentation.feature.auth.viewmodel.LoginUiState
+import kr.co.presentation.feature.auth.viewmodel.LoginScreenState
 import kr.co.presentation.feature.auth.viewmodel.LoginViewModel
+import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -52,7 +46,7 @@ fun LoginScreen(
     onNavigateToSignUpScreen: () -> Unit,
     viewModel: LoginViewModel = hiltViewModel(),
 ) {
-    val state: LoginUiState by viewModel.collectAsState()
+    val state: LoginScreenState by viewModel.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -76,7 +70,7 @@ fun LoginScreen(
 
 @Composable
 fun LoginContent(
-    state: LoginUiState = LoginUiState(),
+    state: LoginScreenState = LoginScreenState(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     intent: (LoginIntent) -> Unit = {}
 ) {
@@ -91,105 +85,83 @@ fun LoginContent(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxWidth()
                 .padding(it)
                 .padding(horizontal = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
         ) {
-            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                modifier = Modifier.padding(top = 36.dp, bottom = 36.dp),
+                text = stringResource(R.string.login),
+                style = MaterialTheme.typography.headlineMedium
+            )
 
-            Column(
+            // Id
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.id),
+                style = MaterialTheme.typography.labelLarge
+            )
+            OutlinedTextField(
                 modifier = Modifier
-                    .padding(top = 24.dp)
-                    .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp))
-                    .background(MaterialTheme.colorScheme.background)
-                    .padding(horizontal = 16.dp)
-                    .fillMaxHeight()
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                value = state.email,
+                onValueChange = { value -> intent(LoginIntent.EmailChanged(value)) },
+                label = { Text(stringResource(R.string.user_id)) }
+            )
+
+            // Password
+            Text(
+                modifier = Modifier.padding(bottom = 8.dp),
+                text = stringResource(R.string.password),
+                style = MaterialTheme.typography.labelLarge
+            )
+            OutlinedTextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                value = state.password,
+                onValueChange = { value -> intent(LoginIntent.PasswordChanged(value)) },
+                label = { Text(stringResource(R.string.user_password)) },
+                visualTransformation = PasswordVisualTransformation()
+            )
+
+            // login button
+            LoadingButton(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 16.dp),
+                text = stringResource(R.string.btn_login),
+                onClick = { intent(LoginIntent.LoginButtonClicked) },
+                isLoading = state.isLoggingIn
+            )
+
+            // sign up text button
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(bottom = 24.dp)
+                    .clickable(onClick = { intent(LoginIntent.SignUpButtonClicked) }),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.Bottom
             ) {
+                Text(text = stringResource(R.string.do_not_have_an_account))
                 Text(
-                    modifier = Modifier.padding(top = 36.dp),
-                    text = stringResource(R.string.login),
-                    style = MaterialTheme.typography.headlineMedium
+                    text = stringResource(R.string.sign_up),
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.padding(start = 4.dp)
                 )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // Id
-                Text(
-                    modifier = Modifier.padding(top = 16.dp),
-                    text = stringResource(R.string.id),
-                    style = MaterialTheme.typography.labelLarge
-                )
-                OutlinedTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = state.id,
-                    onValueChange = { value -> intent(LoginIntent.IdChanged(value)) },
-                    label = { Text(stringResource(R.string.user_id)) }
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                // Password
-                Text(
-                    modifier = Modifier.padding(top = 16.dp),
-                    text = stringResource(R.string.password),
-                    style = MaterialTheme.typography.labelLarge
-                )
-                OutlinedTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = state.password,
-                    onValueChange = { value -> intent(LoginIntent.PasswordChanged(value)) },
-                    label = { Text(stringResource(R.string.user_password)) },
-                    visualTransformation = PasswordVisualTransformation()
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                if (state.isLoggingIn) {
-                    CircularProgressIndicator()
-                } else {
-                    Button(
-                        modifier = Modifier
-                            .padding(vertical = 16.dp)
-                            .fillMaxWidth()
-                            .padding(bottom = 24.dp)
-                            .align(Alignment.CenterHorizontally),
-                        shape = RoundedCornerShape(8.dp),
-                        colors = ButtonDefaults.buttonColors(
-                            containerColor = MaterialTheme.colorScheme.primary,
-                            contentColor = MaterialTheme.colorScheme.onPrimary
-                        ),
-                        onClick = { intent(LoginIntent.LoginButtonClicked) }
-                    ) {
-                        Text(text = stringResource(R.string.btn_login))
-                    }
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .padding(bottom = 24.dp)
-                            .clickable(onClick = { intent(LoginIntent.SignUpButtonClicked) })
-                    ) {
-                        Text(text = stringResource(R.string.do_not_have_an_account))
-                        Text(
-                            text = stringResource(R.string.sign_up),
-                            color = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.padding(start = 4.dp)
-                        )
-                    }
-                }
             }
         }
     }
 }
 
-@Preview(showBackground = true, locale = "ko")
+@Preview(showBackground = true, locale = "ko", name = "LoginContent Preview")
 @Composable
-private fun LoginContentPreview() {
+private fun LoginContentPreview(
+    @PreviewParameter(LoginPreviewDataProvider::class) state: LoginScreenState
+) {
     MinaryTheme {
-        LoginContent()
+        LoginContent(state)
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/screen/SignUpScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/screen/SignUpScreen.kt
@@ -7,8 +7,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -25,14 +23,17 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
+import kr.co.presentation.common.composable.LoadingButton
 import kr.co.presentation.common.extension.getString
+import kr.co.presentation.feature.auth.preview.provider.SignUpPreviewDataProvider
 import kr.co.presentation.feature.auth.viewmodel.SignUpIntent
 import kr.co.presentation.feature.auth.viewmodel.SignUpSideEffect
-import kr.co.presentation.feature.auth.viewmodel.SignUpUiState
+import kr.co.presentation.feature.auth.viewmodel.SignUpScreenState
 import kr.co.presentation.feature.auth.viewmodel.SignUpViewModel
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
@@ -44,7 +45,7 @@ fun SignUpScreen(
     onNavigateToLoginScreen: () -> Unit,
     viewModel: SignUpViewModel = hiltViewModel()
 ) {
-    val state: SignUpUiState by viewModel.collectAsState()
+    val state: SignUpScreenState by viewModel.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -61,13 +62,13 @@ fun SignUpScreen(
     SignUpContent(
         state = state,
         snackbarHostState = snackbarHostState,
-        intent = viewModel::handelIntent
+        intent = viewModel::handleIntent
     )
 }
 
 @Composable
 fun SignUpContent(
-    state: SignUpUiState = SignUpUiState(),
+    state: SignUpScreenState = SignUpScreenState(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     intent: (SignUpIntent) -> Unit = {},
 ) {
@@ -117,9 +118,9 @@ fun SignUpContent(
             )
             OutlinedTextField(
                 modifier = Modifier.fillMaxWidth(),
-                value = state.userName,
+                value = state.name,
                 onValueChange = { value ->
-                    intent(SignUpIntent.UserNameChanged(value))
+                    intent(SignUpIntent.NameChanged(value))
                 },
                 label = { Text(stringResource(R.string.user_name)) }
             )
@@ -156,32 +157,25 @@ fun SignUpContent(
                 visualTransformation = PasswordVisualTransformation()
             )
 
-            // Sign Up Button
-            Button(
+            // sign up button
+            LoadingButton(
                 modifier = Modifier
-                    .padding(vertical = 24.dp)
-                    .fillMaxWidth(),
-                shape = RoundedCornerShape(8.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = MaterialTheme.colorScheme.primary,
-                    contentColor = MaterialTheme.colorScheme.onPrimary
-                ),
+                    .fillMaxWidth()
+                    .padding(vertical = 24.dp),
+                text = stringResource(R.string.sign_up),
                 onClick = { intent(SignUpIntent.SignUpButtonClicked) },
-            ) {
-                Text(
-                    text = stringResource(R.string.sign_up),
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onPrimary
-                )
-            }
+                isLoading = state.isSigningUp
+            )
         }
     }
 }
 
 @Preview(showBackground = true, locale = "ko")
 @Composable
-private fun SignUpContentPreview() {
+private fun SignUpContentPreview(
+    @PreviewParameter(SignUpPreviewDataProvider::class) state: SignUpScreenState
+) {
     MinaryTheme {
-        SignUpContent()
+        SignUpContent(state)
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/LoginViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/LoginViewModel.kt
@@ -9,10 +9,14 @@ import kr.co.domain.feature.auth.exception.AuthException
 import kr.co.domain.feature.auth.usecase.LoginUseCase
 import kr.co.domain.feature.diary.usecase.CheckAndDownloadInitialDiariesUseCase
 import kr.co.presentation.R
+import kr.co.presentation.common.extension.safeCall
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.common.state.LoadState
+import kr.co.presentation.feature.auth.mapper.UserUiModelMapper.toUserUiModel
+import kr.co.presentation.feature.auth.model.UserUiModel
 import kr.co.presentation.feature.auth.navigation.LoginRoute
 import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
@@ -21,10 +25,10 @@ import javax.inject.Inject
 
 
 @Immutable
-data class LoginUiState(
+data class LoginScreenState(
+    val loginLoadState: LoadState<UserUiModel> = LoadState.Uninitialized,
     val isLoggingIn: Boolean = false,
-    val loginError: UiText? = null,
-    val id: String = "",
+    val email: String = "",
     val password: String = ""
 )
 
@@ -36,7 +40,7 @@ sealed interface LoginSideEffect {
 }
 
 sealed interface LoginIntent {
-    data class IdChanged(val newId: String) : LoginIntent
+    data class EmailChanged(val newEmail: String) : LoginIntent
     data class PasswordChanged(val newPassword: String) : LoginIntent
     object LoginButtonClicked : LoginIntent
     object SignUpButtonClicked : LoginIntent
@@ -47,105 +51,86 @@ class LoginViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val loginUseCase: LoginUseCase,
     private val checkAndDownloadInitialDiariesUseCase: CheckAndDownloadInitialDiariesUseCase,
-) : ViewModel(), ContainerHost<LoginUiState, LoginSideEffect> {
+) : ViewModel(), ContainerHost<LoginScreenState, LoginSideEffect> {
 
-    companion object {
-        private const val KEY_ID = "user_id"
-        private const val KEY_PASSWORD = "user_password"
+    private companion object {
+        private const val KEY_EMAIL = "email"
+        private const val KEY_PASSWORD = "password"
     }
 
-    override val container = container<LoginUiState, LoginSideEffect>(LoginUiState())
+    override val container = container<LoginScreenState, LoginSideEffect>(LoginScreenState())
 
     init {
-        initializeState()
+        initState()
     }
 
-    private fun initializeState() = intent {
+    private fun initState() = intent {
         val route = savedStateHandle.toRoute<LoginRoute>()
 
-        val id = savedStateHandle.get<String>(KEY_ID) ?: ""
-        val password = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
+        val savedStateEmail = savedStateHandle[KEY_EMAIL] ?: ""
+        val savedStatePassword = savedStateHandle[KEY_PASSWORD] ?: ""
 
-        reduce { state.copy(id = id, password = password) }
+        reduce { state.copy(email = savedStateEmail, password = savedStatePassword) }
     }
 
     fun handleIntent(intent: LoginIntent) {
         when (intent) {
-            is LoginIntent.IdChanged -> updateId(intent.newId)
+            is LoginIntent.EmailChanged -> updateEmail(intent.newEmail)
             is LoginIntent.PasswordChanged -> updatePassword(intent.newPassword)
             is LoginIntent.LoginButtonClicked -> login()
             is LoginIntent.SignUpButtonClicked -> navigateToSignUpScreen()
         }
     }
 
-    private fun updateId(newId: String) = blockingIntent {
-        reduce { state.copy(id = newId) }
-        savedStateHandle[KEY_ID] = newId
+    private fun updateEmail(newEmail: String) = intent {
+        reduce { state.copy(email = newEmail) }
+        savedStateHandle[KEY_EMAIL] = newEmail
     }
 
-    private fun updatePassword(newPassword: String) = blockingIntent {
+    private fun updatePassword(newPassword: String) = intent {
         reduce { state.copy(password = newPassword) }
-        savedStateHandle[KEY_ID] = newPassword
+        savedStateHandle[KEY_EMAIL] = newPassword
     }
 
     private fun login() = intent {
-        if (state.id.isNullOrBlank()) {
-            postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.id_is_empty)))
-            return@intent
-        }
+        if (!validateInput()) return@intent
 
-        if (state.password.isNullOrBlank()) {
-            postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
-            return@intent
-        }
+        safeCall { loginUseCase(state.email, state.password) }
+            .map { it.toUserUiModel() }
+            .onLoading { isLoading -> reduce { state.copy(isLoggingIn = isLoading) } }
+            .onError { handleLoginError(it) }
+            .launchOnSuccess {
+                checkAndDownloadInitialDiariesUseCase()
+                postSideEffect(LoginSideEffect.NavigateToMainScreen)
+            }
+    }
 
-        reduce {
-            // 로그인 시도 중, 오류 메시지 초기화
-            state.copy(
-                isLoggingIn = true,
-                loginError = UiText.StringResource(R.string.unknown_error)
-            )
-        }
-
-        val login = loginUseCase(state.id, state.password)
-        login.onSuccess {
-            checkAndDownloadInitialDiariesUseCase()
-
-            reduce {
-                state.copy(
-                    isLoggingIn = false,
-                    loginError = UiText.StringResource(R.string.unknown_error)
-                )
+    private suspend fun SimpleSyntax<LoginScreenState, LoginSideEffect>.validateInput(): Boolean {
+        return when {
+            state.email.isBlank() -> {
+                postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.id_is_empty)))
+                false
             }
 
-            postSideEffect(LoginSideEffect.NavigateToMainScreen)
-        }.onFailure { error ->
-            reduce {
-                // 로그인 실패, 오류 메시지 업데이트
-                state.copy(
-                    isLoggingIn = false,
-                    loginError = UiText.StringResource(R.string.login_failed)
-                )
+            state.password.isBlank() -> {
+                postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
+                false
             }
 
-            when (error) {
-                is AuthException.SignInUserIsNullException -> {
-                    postSideEffect(LoginSideEffect.ShowMsg(UiText.StringResource(R.string.login_failed)))
-                }
-
-                else -> {
-                    val uiText = error.message
-                        .takeIf { !it.isNullOrBlank() }
-                        ?.let { UiText.DynamicString(it) }
-                        ?: UiText.StringResource(R.string.unknown_error)
-
-                    postSideEffect(LoginSideEffect.ShowMsg(uiText))
-                }
-            }
+            else -> true
         }
     }
 
     private fun navigateToSignUpScreen() = intent {
         postSideEffect(LoginSideEffect.NavigateToSignUpScreen)
+    }
+
+    private fun handleLoginError(error: Throwable) = intent {
+        val message = when (error) {
+            is AuthException.SignInUserIsNullException -> UiText.StringResource(R.string.login_failed)
+            else -> error.message?.let { UiText.DynamicString(it) }
+                ?: UiText.StringResource(R.string.unknown_error)
+        }
+        postSideEffect(LoginSideEffect.ShowMsg(message))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/SignUpViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/auth/viewmodel/SignUpViewModel.kt
@@ -7,10 +7,14 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.domain.feature.auth.exception.AuthException
 import kr.co.domain.feature.auth.usecase.SignUpUseCase
 import kr.co.presentation.R
+import kr.co.presentation.common.extension.safeCall
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.common.state.LoadState
+import kr.co.presentation.feature.auth.mapper.UserUiModelMapper.toUserUiModel
+import kr.co.presentation.feature.auth.model.UserUiModel
 import kr.co.presentation.feature.auth.navigation.SignUpRoute
 import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.SimpleSyntax
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
@@ -20,9 +24,11 @@ import javax.inject.Inject
 
 
 @Immutable
-data class SignUpUiState(
+data class SignUpScreenState(
+    val signUpLoadState: LoadState<UserUiModel> = LoadState.Uninitialized,
+    val isSigningUp: Boolean = false,
     val email: String = "",
-    val userName: String = "",
+    val name: String = "",
     val password: String = "",
     val confirmPassword: String = ""
 )
@@ -35,7 +41,7 @@ sealed interface SignUpSideEffect {
 
 sealed interface SignUpIntent {
     data class EmailChanged(val newEmail: String) : SignUpIntent
-    data class UserNameChanged(val newUserName: String) : SignUpIntent
+    data class NameChanged(val newName: String) : SignUpIntent
     data class PasswordChanged(val newPassword: String) : SignUpIntent
     data class ConfirmPasswordChanged(val newConfirmPassword: String) : SignUpIntent
     object SignUpButtonClicked : SignUpIntent
@@ -45,115 +51,116 @@ sealed interface SignUpIntent {
 class SignUpViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val signUpUseCase: SignUpUseCase
-) : ViewModel(), ContainerHost<SignUpUiState, SignUpSideEffect> {
+) : ViewModel(), ContainerHost<SignUpScreenState, SignUpSideEffect> {
 
-    companion object {
+    private companion object {
         private const val KEY_EMAIL = "email"
-        private const val KEY_USER_NAME = "user_name"
+        private const val KEY_NAME = "name"
         private const val KEY_PASSWORD = "password"
         private const val KEY_CONFIRM_PASSWORD = "confirm_password"
     }
 
-    override val container = container<SignUpUiState, SignUpSideEffect>(SignUpUiState())
+    override val container = container<SignUpScreenState, SignUpSideEffect>(SignUpScreenState())
 
     init {
-        initializeState()
+        initState()
     }
 
-    private fun initializeState() = intent {
+    private fun initState() = intent {
         val route = savedStateHandle.toRoute<SignUpRoute>()
 
-        val email = savedStateHandle.get<String>(KEY_EMAIL) ?: ""
-        val userName = savedStateHandle.get<String>(KEY_USER_NAME) ?: ""
-        val password = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
-        val confirmPassword = savedStateHandle.get<String>(KEY_CONFIRM_PASSWORD) ?: ""
+        val savedStateEmail = savedStateHandle[KEY_EMAIL] ?: ""
+        val savedStateName = savedStateHandle[KEY_NAME] ?: ""
+        val savedStatePassword = savedStateHandle[KEY_PASSWORD] ?: ""
+        val savedStateConfirmPassword = savedStateHandle[KEY_CONFIRM_PASSWORD] ?: ""
 
         reduce {
             state.copy(
-                email = email,
-                userName = userName,
-                password = password,
-                confirmPassword = confirmPassword
+                email = savedStateEmail,
+                name = savedStateName,
+                password = savedStatePassword,
+                confirmPassword = savedStateConfirmPassword
             )
         }
     }
 
-    fun handelIntent(intent: SignUpIntent) {
+    fun handleIntent(intent: SignUpIntent) {
         when (intent) {
             is SignUpIntent.EmailChanged -> updateEmail(intent.newEmail)
-            is SignUpIntent.UserNameChanged -> updateUserName(intent.newUserName)
+            is SignUpIntent.NameChanged -> updateName(intent.newName)
             is SignUpIntent.PasswordChanged -> updatePassword(intent.newPassword)
             is SignUpIntent.ConfirmPasswordChanged -> updateConfirmPassword(intent.newConfirmPassword)
             is SignUpIntent.SignUpButtonClicked -> signUp()
         }
     }
 
-    private fun updateEmail(newEmail: String) = blockingIntent {
+    private fun updateEmail(newEmail: String) = intent {
         reduce { state.copy(email = newEmail) }
         savedStateHandle[KEY_EMAIL] = newEmail
     }
 
-    private fun updateUserName(newUserName: String) = blockingIntent {
-        reduce { state.copy(userName = newUserName) }
-        savedStateHandle[KEY_USER_NAME] = newUserName
+    private fun updateName(newName: String) = intent {
+        reduce { state.copy(name = newName) }
+        savedStateHandle[KEY_NAME] = newName
     }
 
-    private fun updatePassword(newPassword: String) = blockingIntent {
+    private fun updatePassword(newPassword: String) = intent {
         reduce { state.copy(password = newPassword) }
         savedStateHandle[KEY_PASSWORD] = newPassword
     }
 
-    private fun updateConfirmPassword(newConfirmPassword: String) = blockingIntent {
+    private fun updateConfirmPassword(newConfirmPassword: String) = intent {
         reduce { state.copy(confirmPassword = newConfirmPassword) }
         savedStateHandle[KEY_CONFIRM_PASSWORD] = newConfirmPassword
     }
 
     private fun signUp() = intent {
-        if (state.email.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.email_is_empty)))
-            return@intent
-        }
+        if (!validateInput()) return@intent
 
-        if (state.userName.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.name_is_empty)))
-            return@intent
-        }
+        safeCall { signUpUseCase(state.email, state.password, state.name) }
+            .map { it.toUserUiModel() }
+            .onLoading { isLoading -> reduce { state.copy(isSigningUp = isLoading) } }
+            .onError { handleSignUpError(it) }
+            .launchOnSuccess { postSideEffect(SignUpSideEffect.NavigateToLoginScreen) }
+    }
 
-        if (state.password.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
-            return@intent
-        }
-
-        if (state.confirmPassword.isNullOrBlank()) {
-            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.confirm_password_is_empty)))
-            return@intent
-        }
-
-        if (state.password != state.confirmPassword) {
-            postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_not_match)))
-            return@intent
-        }
-
-        val signUp = signUpUseCase(state.email, state.password, state.userName)
-        signUp.onSuccess { user ->
-            postSideEffect(SignUpSideEffect.NavigateToLoginScreen)
-        }.onFailure { error ->
-            when (error) {
-                is AuthException.CreateUserIsNullException -> {
-                    postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.account_creation_failed)))
-                }
-
-                else -> {
-                    val uiText = error.message
-                        .takeIf {
-                            !it.isNullOrBlank()
-                        }?.let {
-                            UiText.DynamicString(it)
-                        } ?: UiText.StringResource(R.string.unknown_error)
-
-                    postSideEffect(SignUpSideEffect.ShowMsg(uiText))
-                }
+    private suspend fun SimpleSyntax<SignUpScreenState, SignUpSideEffect>.validateInput(): Boolean {
+        return when {
+            state.email.isBlank() -> {
+                postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.email_is_empty)))
+                false
             }
+
+            state.name.isBlank() -> {
+                postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.name_is_empty)))
+                false
+            }
+
+            state.password.isBlank() -> {
+                postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_is_empty)))
+                false
+            }
+
+            state.confirmPassword.isBlank() -> {
+                postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.confirm_password_is_empty)))
+                false
+            }
+
+            state.password != state.confirmPassword -> {
+                postSideEffect(SignUpSideEffect.ShowMsg(UiText.StringResource(R.string.password_not_match)))
+                false
+            }
+
+            else -> true
         }
+    }
+
+    private fun handleSignUpError(error: Throwable) = intent {
+        val message = when (error) {
+            is AuthException.CreateUserIsNullException -> UiText.StringResource(R.string.account_creation_failed)
+            else -> error.message?.let { UiText.DynamicString(it) }
+                ?: UiText.StringResource(R.string.unknown_error)
+        }
+        postSideEffect(SignUpSideEffect.ShowMsg(message))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/composable/DiarySkeleton.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/composable/DiarySkeleton.kt
@@ -1,0 +1,108 @@
+package kr.co.presentation.feature.diary.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import kr.co.presentation.R
+import kr.co.presentation.common.skeleton.SkeletonButton
+import kr.co.presentation.common.skeleton.SkeletonIconButton
+import kr.co.presentation.common.skeleton.SkeletonSpacer
+import kr.co.presentation.theme.MinaryTheme
+
+
+@Composable
+fun SkeletonDiaryContent() {
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            SkeletonDiaryTopBar()
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            SkeletonSpacer(
+                modifier = Modifier
+                    .padding(bottom = 8.dp)
+                    .fillMaxWidth(0.5f)
+                    .height(20.dp)
+            )
+            SkeletonSpacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(24.dp)
+                    .padding(start = 16.dp, end = 16.dp)
+
+            )
+            SkeletonSpacer(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 16.dp, end = 16.dp, top = 8.dp, bottom = 8.dp),
+            )
+        }
+    }
+}
+
+@Composable
+fun SkeletonDiaryTopBar() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .systemBarsPadding()
+            .padding(start = 16.dp, end = 16.dp)
+    ) {
+        SkeletonSpacer(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .size(24.dp),
+            shape = CircleShape
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            SkeletonIconButton {
+                Icon(
+                    painter = painterResource(android.R.drawable.ic_menu_delete),
+                    contentDescription = ""
+                )
+            }
+
+            SkeletonButton {
+                Text(stringResource(R.string.diary_edit_button))
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, locale = "ko")
+@Composable
+private fun SkeletonDiaryContentPreview() {
+    MinaryTheme {
+        SkeletonDiaryContent()
+    }
+}

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/preview/factory/DiaryPreviewDataFactory.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/preview/factory/DiaryPreviewDataFactory.kt
@@ -7,21 +7,48 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import kr.co.domain.feature.emotion.Emotion
 import kr.co.presentation.R
+import kr.co.presentation.common.state.LoadState
 import kr.co.presentation.feature.diary.model.DiaryUiModel
+import kr.co.presentation.feature.diary.preview.model.DiaryPreviewData
+import kr.co.presentation.feature.diary.viewmodel.DiaryScreenState
 import java.time.LocalDate
 
 
 object DiaryPreviewDataFactory {
 
     @Composable
-    fun createDiary(emotion: Emotion, context: Context = LocalContext.current): DiaryUiModel {
-        val (titleRes, contentRes) = getDiaryStringResources(emotion)
+    fun createDiaryUiState(
+        diaryPreviewData: DiaryPreviewData,
+        context: Context = LocalContext.current
+    ): DiaryScreenState {
+        val (titleResId, contentResId) = getDiaryStringResources(diaryPreviewData.emotion)
+
+        return DiaryScreenState(
+            screenMode = diaryPreviewData.screenMode,
+            diaryLoadState = LoadState.Success(
+                DiaryUiModel(
+                    id = 0L,
+                    date = LocalDate.now(),
+                    title = context.getString(titleResId),
+                    content = context.getString(contentResId),
+                    emotion = diaryPreviewData.emotion
+                )
+            )
+        )
+    }
+
+    @Composable
+    fun createDiaryUiModel(
+        emotion: Emotion,
+        context: Context = LocalContext.current
+    ): DiaryUiModel {
+        val (titleResId, contentResId) = getDiaryStringResources(emotion)
 
         return DiaryUiModel(
             id = 0L,
             date = LocalDate.now(),
-            title = context.getString(titleRes),
-            content = context.getString(contentRes),
+            title = context.getString(titleResId),
+            content = context.getString(contentResId),
             emotion = emotion
         )
     }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/preview/model/DiaryPreviewData.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/preview/model/DiaryPreviewData.kt
@@ -7,6 +7,6 @@ import kr.co.presentation.feature.diary.viewmodel.DiaryScreenMode
 
 @Immutable
 data class DiaryPreviewData(
-    val emotion: Emotion,
-    val screenMode: DiaryScreenMode
+    val screenMode: DiaryScreenMode = DiaryScreenMode.Edit,
+    val emotion: Emotion = Emotion.UNKNOWN,
 )

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/preview/provider/DiaryPreviewDataProvider.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/preview/provider/DiaryPreviewDataProvider.kt
@@ -6,10 +6,16 @@ import kr.co.presentation.feature.diary.preview.model.DiaryPreviewData
 import kr.co.presentation.feature.diary.viewmodel.DiaryScreenMode
 
 
-internal class DiaryStatePreviewDataProvider : PreviewParameterProvider<DiaryPreviewData> {
+internal class DiaryPreviewDataProvider : PreviewParameterProvider<DiaryPreviewData> {
 
     override val values: Sequence<DiaryPreviewData> = sequenceOf(
-        DiaryPreviewData(Emotion.EXCITEMENT, DiaryScreenMode.Edit),
-        DiaryPreviewData(Emotion.ENTRANCEMENT, DiaryScreenMode.Preview),
+        DiaryPreviewData(
+            screenMode = DiaryScreenMode.Edit,
+            emotion = Emotion.EXCITEMENT
+        ),
+        DiaryPreviewData(
+            screenMode = DiaryScreenMode.Preview,
+            emotion = Emotion.ENTRANCEMENT
+        ),
     )
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/screen/DiaryScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/screen/DiaryScreen.kt
@@ -1,6 +1,5 @@
 package kr.co.presentation.feature.diary.screen
 
-import android.R
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,10 +9,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -21,15 +20,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,15 +36,21 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import kotlinx.coroutines.launch
 import kr.co.domain.feature.emotion.Emotion
+import kr.co.presentation.R
+import kr.co.presentation.common.composable.LoadStateContent
+import kr.co.presentation.common.composable.LoadingButton
+import kr.co.presentation.common.composable.LoadingIconButton
 import kr.co.presentation.common.extension.color
 import kr.co.presentation.common.extension.getString
+import kr.co.presentation.feature.diary.composable.SkeletonDiaryContent
+import kr.co.presentation.feature.diary.model.DiaryUiModel
 import kr.co.presentation.feature.diary.preview.factory.DiaryPreviewDataFactory
 import kr.co.presentation.feature.diary.preview.model.DiaryPreviewData
-import kr.co.presentation.feature.diary.preview.provider.DiaryStatePreviewDataProvider
+import kr.co.presentation.feature.diary.preview.provider.DiaryPreviewDataProvider
 import kr.co.presentation.feature.diary.viewmodel.DiaryIntent
 import kr.co.presentation.feature.diary.viewmodel.DiaryScreenMode
+import kr.co.presentation.feature.diary.viewmodel.DiaryScreenState
 import kr.co.presentation.feature.diary.viewmodel.DiarySideEffect
-import kr.co.presentation.feature.diary.viewmodel.DiaryUiState
 import kr.co.presentation.feature.diary.viewmodel.DiaryViewModel
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
@@ -59,7 +62,7 @@ fun DiaryScreen(
     onNavigateToMainScreen: () -> Unit = {},
     viewModel: DiaryViewModel = hiltViewModel()
 ) {
-    val state: DiaryUiState by viewModel.collectAsState()
+    val state: DiaryScreenState by viewModel.collectAsState()
     val coroutineScope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
@@ -73,16 +76,27 @@ fun DiaryScreen(
         }
     }
 
-    DiaryContent(
-        state = state,
-        snackbarHostState = snackbarHostState,
-        intent = viewModel::handleIntent
-    )
+    LoadStateContent(
+        loadState = state.diaryLoadState,
+        loading = {
+            SkeletonDiaryContent()
+        }
+    ) { diaryUiModel ->
+        DiaryContent(
+            diaryUiModel = diaryUiModel,
+            screenMode = state.screenMode,
+            isBtnLoading = state.isDoneBtnLoading,
+            snackbarHostState = snackbarHostState,
+            intent = viewModel::handleIntent
+        )
+    }
 }
 
 @Composable
 fun DiaryContent(
-    state: DiaryUiState = DiaryUiState(),
+    diaryUiModel: DiaryUiModel,
+    screenMode: DiaryScreenMode = DiaryScreenMode.Preview,
+    isBtnLoading: Boolean = false,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     intent: (DiaryIntent) -> Unit = {}
 ) {
@@ -90,13 +104,13 @@ fun DiaryContent(
         modifier = Modifier.fillMaxSize(),
         snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
-            when (state.screenMode) {
-                DiaryScreenMode.Edit -> EditTopBar(state.diaryUiModel.emotion, intent)
-                DiaryScreenMode.Preview -> PreviewTopBar(state.diaryUiModel.emotion, intent)
+            when (screenMode) {
+                DiaryScreenMode.Edit -> EditTopBar(diaryUiModel.emotion, isBtnLoading, intent)
+                DiaryScreenMode.Preview -> PreviewTopBar(diaryUiModel.emotion, isBtnLoading, intent)
             }
         }
     ) { paddingValues ->
-        val enabled = (state.screenMode == DiaryScreenMode.Edit)
+        val enabled = (screenMode == DiaryScreenMode.Edit)
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -106,30 +120,30 @@ fun DiaryContent(
         ) {
             Text(
                 modifier = Modifier.padding(bottom = 8.dp),
-                text = state.diaryUiModel.date.toString(),
+                text = diaryUiModel.date.toString(),
                 fontSize = 20.sp
             )
             TextField(
-                value = state.diaryUiModel.title,
+                value = diaryUiModel.title,
                 onValueChange = { intent(DiaryIntent.TitleChanged(it)) },
                 modifier = Modifier.fillMaxWidth(),
                 enabled = enabled,
                 readOnly = !enabled,
                 singleLine = true,
                 maxLines = 1,
-                label = { Text("Title") },
+                label = { Text(stringResource(R.string.diary_title_hint)) },
                 textStyle = TextStyle(
                     fontWeight = FontWeight.Bold,
                     fontSize = 24.sp,
                 )
             )
             TextField(
-                value = state.diaryUiModel.content,
+                value = diaryUiModel.content,
                 onValueChange = { intent(DiaryIntent.ContentChanged(it)) },
                 modifier = Modifier.fillMaxSize(),
                 enabled = enabled,
                 readOnly = !enabled,
-                label = { Text("Content") },
+                label = { Text(stringResource(R.string.diary_content_hint)) },
                 textStyle = TextStyle(
                     fontWeight = FontWeight.Normal,
                     fontSize = 20.sp,
@@ -142,12 +156,14 @@ fun DiaryContent(
 @Composable
 fun EditTopBar(
     emotion: Emotion = Emotion.UNKNOWN,
+    isBtnLoading: Boolean = false,
     intent: (DiaryIntent) -> Unit = {}
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .systemBarsPadding()
+            .padding(start = 16.dp, end = 16.dp)
     ) {
         EmotionIcon(
             modifier = Modifier.align(Alignment.CenterStart),
@@ -159,24 +175,26 @@ fun EditTopBar(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Button(onClick = { intent(DiaryIntent.DoneButtonClicked) }) {
-                Text("Done")
-            }
+            LoadingButton(
+                text = stringResource(R.string.diary_done_button),
+                isLoading = isBtnLoading,
+                onClick = { intent(DiaryIntent.DoneButtonClicked) },
+            )
         }
     }
-
-
 }
 
 @Composable
 fun PreviewTopBar(
     emotion: Emotion = Emotion.UNKNOWN,
+    isBtnLoading: Boolean = false,
     intent: (DiaryIntent) -> Unit = {}
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(16.dp),
+            .systemBarsPadding()
+            .padding(start = 16.dp, end = 16.dp)
     ) {
         EmotionIcon(
             modifier = Modifier.align(Alignment.CenterStart),
@@ -188,24 +206,18 @@ fun PreviewTopBar(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            var isToggled by rememberSaveable { mutableStateOf(false) }
-
-            IconButton(
-                onClick = {
-                    isToggled = !isToggled
-                    intent(DiaryIntent.DeleteButtonClicked)
-                }
+            LoadingIconButton(
+                onClick = { intent(DiaryIntent.DeleteButtonClicked) },
+                isLoading = isBtnLoading
             ) {
                 Icon(
-                    painter =
-                        if (isToggled) painterResource(R.drawable.ic_menu_delete)
-                        else painterResource(R.drawable.ic_menu_delete),
-                    contentDescription = if (isToggled) "Selected icon button" else "Unselected icon button."
+                    painter = painterResource(android.R.drawable.ic_menu_delete),
+                    contentDescription = stringResource(R.string.diary_delete_button_cd)
                 )
             }
 
             Button(onClick = { intent(DiaryIntent.EditButtonClicked) }) {
-                Text("Edit")
+                Text(stringResource(R.string.diary_edit_button))
             }
         }
     }
@@ -225,20 +237,14 @@ fun EmotionIcon(
     }
 }
 
-
 @Preview(showBackground = true, locale = "ko")
 @Composable
 private fun DiaryContentPreview(
-    @PreviewParameter(DiaryStatePreviewDataProvider::class) diaryPreviewData: DiaryPreviewData,
+    @PreviewParameter(DiaryPreviewDataProvider::class) diaryPreviewData: DiaryPreviewData,
 ) {
-    val diary = DiaryPreviewDataFactory.createDiary(diaryPreviewData.emotion)
-
-    val state = DiaryUiState(
-        screenMode = diaryPreviewData.screenMode,
-        diaryUiModel = diary
-    )
+    val diaryUiModel = DiaryPreviewDataFactory.createDiaryUiModel(diaryPreviewData.emotion)
 
     MinaryTheme {
-        DiaryContent(state)
+        DiaryContent(diaryUiModel, diaryPreviewData.screenMode)
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/viewmodel/DiaryViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/viewmodel/DiaryViewModel.kt
@@ -13,13 +13,17 @@ import kr.co.domain.feature.diary.usecase.GetDiaryUseCase
 import kr.co.domain.feature.diary.usecase.UpsertDiaryUseCase
 import kr.co.domain.feature.emotion.Emotion
 import kr.co.presentation.R
+import kr.co.presentation.common.extension.getLocalDate
+import kr.co.presentation.common.extension.getLong
+import kr.co.presentation.common.extension.safeCall
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.common.state.LoadState
+import kr.co.presentation.common.state.data
 import kr.co.presentation.feature.diary.mapper.DiaryUiModelMapper.toDiary
 import kr.co.presentation.feature.diary.mapper.DiaryUiModelMapper.toDiaryUiModel
 import kr.co.presentation.feature.diary.model.DiaryUiModel
 import kr.co.presentation.feature.diary.navigation.DiaryRoute
 import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
@@ -31,14 +35,19 @@ import javax.inject.Inject
 @Immutable
 @Parcelize
 sealed interface DiaryScreenMode : Parcelable {
-    @Parcelize object Edit : DiaryScreenMode
-    @Parcelize object Preview : DiaryScreenMode
+    @Parcelize
+    object Edit : DiaryScreenMode
+
+    @Parcelize
+    object Preview : DiaryScreenMode
 }
 
 @Immutable
-data class DiaryUiState(
-    val screenMode: DiaryScreenMode = DiaryScreenMode.Preview,
-    val diaryUiModel: DiaryUiModel = DiaryUiModel()
+data class DiaryScreenState(
+    val screenMode: DiaryScreenMode = DiaryScreenMode.Edit,
+    val diaryLoadState: LoadState<DiaryUiModel> = LoadState.Uninitialized,
+    val isDoneBtnLoading: Boolean = false,
+    val isDeleteBtnLoading: Boolean = false,
 )
 
 @Immutable
@@ -61,66 +70,96 @@ class DiaryViewModel @Inject constructor(
     private val getDiaryUseCase: GetDiaryUseCase,
     private val deleteDiaryUseCase: DeleteDiaryUseCase,
     private val upsertDiaryUseCase: UpsertDiaryUseCase,
-) : ViewModel(), ContainerHost<DiaryUiState, DiarySideEffect> {
+) : ViewModel(), ContainerHost<DiaryScreenState, DiarySideEffect> {
 
-    companion object {
-        private const val KEY_SCREEN_MODE = "screen_mode"
-        private const val KEY_DIARY_ID = "diary_id"
-        private const val KEY_PASSWORD = "title"
+    private companion object {
+        private const val KEY_ID = "id"
+        private const val KEY_DATE = "date"
+        private const val KEY_TITLE = "title"
         private const val KEY_CONTENT = "content"
         private const val KEY_EMOTION = "emotion"
     }
 
     override val container =
-        container<DiaryUiState, DiarySideEffect>(DiaryUiState())
+        container<DiaryScreenState, DiarySideEffect>(DiaryScreenState())
 
     init {
-        initializeState()
+        loadDiary()
     }
 
-    private fun initializeState() = intent {
+    private fun loadDiary() = intent {
         val route = savedStateHandle.toRoute<DiaryRoute>()
-        val date = LocalDate.of(route.year, route.month, route.date)
+        val targetDate = LocalDate.of(route.year, route.month, route.date)
 
-        val screenMode = savedStateHandle.get<DiaryScreenMode>(KEY_SCREEN_MODE) ?: DiaryScreenMode.Edit
-        val diaryId = savedStateHandle.get<Long>(KEY_DIARY_ID) ?: 0L
-        val title = savedStateHandle.get<String>(KEY_PASSWORD) ?: ""
-        val content = savedStateHandle.get<String>(KEY_CONTENT) ?: ""
-        val emotion = savedStateHandle.get<Emotion>(KEY_EMOTION) ?: Emotion.UNKNOWN
+        val saveStateDiaryId = savedStateHandle.getLong(KEY_ID, 0L)
+        val saveStateDiaryDate = savedStateHandle.getLocalDate(KEY_DATE, targetDate)
+        val saveStateDiaryTitle = savedStateHandle[KEY_TITLE] ?: ""
+        val saveStateDiaryContent = savedStateHandle[KEY_CONTENT] ?: ""
+        val saveStateDiaryEmotion = savedStateHandle[KEY_EMOTION] ?: Emotion.UNKNOWN
 
-        getDiaryUseCase(date).onSuccess { diary ->
-            val diaryUiModel = diary.toDiaryUiModel()
-            val screenMode = DiaryScreenMode.Preview
-            reduce {
-                state.copy(
-                    screenMode = screenMode,
-                    diaryUiModel = diaryUiModel,
+        if (saveStateDiaryTitle.isNotBlank() || saveStateDiaryContent.isNotBlank()) {
+            // 작성중인 일기 내용이 있었다면
+            setEditState(
+                DiaryUiModel(
+                    id = saveStateDiaryId,
+                    date = saveStateDiaryDate,
+                    title = saveStateDiaryTitle,
+                    content = saveStateDiaryContent,
+                    emotion = saveStateDiaryEmotion,
                 )
-            }
-            savedStateHandle[KEY_SCREEN_MODE] = screenMode
-            savedStateHandle[KEY_DIARY_ID] = diaryUiModel.id
-            savedStateHandle[KEY_PASSWORD] = diaryUiModel.title
-            savedStateHandle[KEY_CONTENT] = diaryUiModel.content
-            savedStateHandle[KEY_EMOTION] = diaryUiModel.emotion
-        }.onFailure { error ->
-            when (error) {
-                is DiaryNotFoundException -> {
-                    reduce {
-                        state.copy(
-                            screenMode = screenMode,
-                            diaryUiModel = DiaryUiModel(
-                                id = diaryId,
-                                date = date,
-                                title = title,
-                                content = content,
-                                emotion = emotion,
-                            )
-                        )
+            )
+        } else {
+            // 작성중인 일기 내용이 없다면, DB에서 가져오기 실행
+            safeCall { getDiaryUseCase(targetDate) }
+                .map { it.toDiaryUiModel() }
+                .launchAsLoadState { loadState ->
+                    when (loadState) {
+                        is LoadState.Success -> {
+                            setPreviewState(loadState.data)
+                            saveDiaryToSavedState(loadState.data)
+                        }
+
+                        is LoadState.Error -> {
+                            when (loadState.exception) {
+                                is DiaryNotFoundException -> setNewDiaryState(targetDate)
+                                else -> {
+                                    loadState.exception?.let { handleDiaryError(it) }
+                                    postSideEffect(DiarySideEffect.NavigateToMainScreen)
+                                }
+                            }
+                        }
+
+                        is LoadState.Loading -> reduce { state.copy(diaryLoadState = loadState) }
+                        else -> {}
                     }
                 }
+        }
+    }
 
-                else -> postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
-            }
+    private fun setPreviewState(diaryUiModel: DiaryUiModel) = intent {
+        reduce {
+            state.copy(
+                screenMode = DiaryScreenMode.Preview,
+                diaryLoadState = LoadState.Success(diaryUiModel)
+            )
+        }
+    }
+
+    private fun setEditState(diaryUiModel: DiaryUiModel) = intent {
+        reduce {
+            state.copy(
+                screenMode = DiaryScreenMode.Edit,
+                diaryLoadState = LoadState.Success(diaryUiModel)
+            )
+        }
+    }
+
+    private fun setNewDiaryState(date: LocalDate) = intent {
+        reduce {
+            state.copy(
+                screenMode = DiaryScreenMode.Edit,
+                diaryLoadState = LoadState.Success(DiaryUiModel(date = date))
+            )
         }
     }
 
@@ -129,72 +168,75 @@ class DiaryViewModel @Inject constructor(
             is DiaryIntent.TitleChanged -> updateTitle(intent.newTitle)
             is DiaryIntent.ContentChanged -> updateContent(intent.newContent)
             is DiaryIntent.DeleteButtonClicked -> deleteDiary()
-            is DiaryIntent.EditButtonClicked -> changeScreenMode(DiaryScreenMode.Edit)
-            is DiaryIntent.DoneButtonClicked -> updateDiary()
+            is DiaryIntent.EditButtonClicked -> setScreenMode(DiaryScreenMode.Edit)
+            is DiaryIntent.DoneButtonClicked -> saveDiary()
         }
     }
 
-    private fun updateTitle(newTitle: String) = blockingIntent {
-        reduce { state.copy(diaryUiModel = state.diaryUiModel.copy(title = newTitle)) }
-        savedStateHandle[KEY_PASSWORD] = newTitle
+    private fun updateTitle(newTitle: String) = intent {
+        val diaryUiModel = state.diaryLoadState.data ?: return@intent
+
+        reduce { state.copy(diaryLoadState = LoadState.Success(diaryUiModel.copy(title = newTitle))) }
+        savedStateHandle[KEY_TITLE] = newTitle
     }
 
-    private fun updateContent(newContent: String) = blockingIntent {
-        reduce { state.copy(diaryUiModel = state.diaryUiModel.copy(content = newContent)) }
+    private fun updateContent(newContent: String) = intent {
+        val diaryUiModel = state.diaryLoadState.data ?: return@intent
+
+        reduce { state.copy(diaryLoadState = LoadState.Success(diaryUiModel.copy(content = newContent))) }
         savedStateHandle[KEY_CONTENT] = newContent
     }
 
     private fun deleteDiary() = intent {
-        deleteDiaryUseCase(
-            state.diaryUiModel.toDiary()
-        ).onSuccess {
-            postSideEffect(DiarySideEffect.NavigateToMainScreen)
-        }.onFailure { error ->
-            postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
-        }
+        val diaryUiModel = state.diaryLoadState.data ?: return@intent
+
+        safeCall { deleteDiaryUseCase(diaryUiModel.toDiary()) }
+            .onLoading { reduce { state.copy(isDeleteBtnLoading = it) } }
+            .onError { handleDiaryError(it) }
+            .launchOnSuccess { postSideEffect(DiarySideEffect.NavigateToMainScreen) }
     }
 
-    private fun changeScreenMode(screenMode: DiaryScreenMode) = intent {
+    private fun setScreenMode(screenMode: DiaryScreenMode) = intent {
         reduce { state.copy(screenMode = screenMode) }
-        savedStateHandle[KEY_SCREEN_MODE] = screenMode
     }
 
-    private fun updateDiary() = intent {
-        if (state.diaryUiModel.title.isNullOrBlank()) {
+    private fun saveDiary() = intent {
+        val diaryUiModel = state.diaryLoadState.data ?: return@intent
+
+        if (diaryUiModel.title.isBlank()) {
             postSideEffect(DiarySideEffect.ShowMsg(UiText.StringResource(R.string.diary_title_is_empty)))
             return@intent
         }
 
-        if (state.diaryUiModel.content.isNullOrBlank()) {
+        if (diaryUiModel.content.isBlank()) {
             postSideEffect(DiarySideEffect.ShowMsg(UiText.StringResource(R.string.diary_content_is_empty)))
             return@intent
         }
 
-        upsertDiaryUseCase(
-            state.diaryUiModel.toDiary()
-        ).onSuccess { diary ->
-            val diaryUiModel = diary.toDiaryUiModel()
-            val screenMode = DiaryScreenMode.Preview
-            reduce {
-                state.copy(
-                    screenMode = screenMode,
-                    diaryUiModel = diaryUiModel
-                )
+        safeCall { upsertDiaryUseCase(diaryUiModel.toDiary()) }
+            .map { it.toDiaryUiModel() }
+            .onLoading { reduce { state.copy(isDoneBtnLoading = it) } }
+            .onError { handleDiaryError(it) }
+            .launchOnSuccess { diaryUiModel ->
+                setPreviewState(diaryUiModel)
+                saveDiaryToSavedState(diaryUiModel)
+                postSideEffect(DiarySideEffect.ShowMsg(UiText.StringResource(R.string.diary_saved)))
             }
-            savedStateHandle[KEY_SCREEN_MODE] = screenMode
-            savedStateHandle[KEY_DIARY_ID] = diaryUiModel.id
-            savedStateHandle[KEY_PASSWORD] = diaryUiModel.title
-            savedStateHandle[KEY_CONTENT] = diaryUiModel.content
-            savedStateHandle[KEY_EMOTION] = diaryUiModel.emotion
-        }.onFailure { error ->
-            postSideEffect(DiarySideEffect.ShowMsg(handleErrorMsg(error)))
-        }
     }
 
-    private fun handleErrorMsg(error: Throwable): UiText {
-        return error.message
-            .takeIf { !it.isNullOrBlank() }
+    private fun saveDiaryToSavedState(diaryUiModel: DiaryUiModel) = intent {
+        savedStateHandle[KEY_ID] = diaryUiModel.id
+        savedStateHandle[KEY_DATE] = diaryUiModel.date.toEpochDay()
+        savedStateHandle[KEY_TITLE] = diaryUiModel.title
+        savedStateHandle[KEY_CONTENT] = diaryUiModel.content
+        savedStateHandle[KEY_EMOTION] = diaryUiModel.emotion
+    }
+
+    private fun handleDiaryError(error: Throwable) = intent {
+        val message = error.message
             ?.let { UiText.DynamicString(it) }
             ?: UiText.StringResource(R.string.unknown_error)
+
+        postSideEffect(DiarySideEffect.ShowMsg(message))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/main/preview/LoadStatePreviewDataProvider.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/preview/LoadStatePreviewDataProvider.kt
@@ -1,0 +1,15 @@
+package kr.co.presentation.main.preview
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import kr.co.presentation.common.state.LoadState
+
+
+internal class LoadStatePreviewDataProvider : PreviewParameterProvider<LoadState<Unit>> {
+
+    override val values: Sequence<LoadState<Unit>> = sequenceOf(
+        LoadState.Uninitialized,
+        LoadState.Loading,
+        LoadState.Error(),
+        LoadState.Success(Unit)
+    )
+}

--- a/presentation/src/main/java/kr/co/presentation/main/screen/MainActivity.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/screen/MainActivity.kt
@@ -4,21 +4,36 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
+import kr.co.presentation.R
+import kr.co.presentation.common.composable.LoadStateContent
 import kr.co.presentation.common.extension.getString
+import kr.co.presentation.common.state.LoadState
 import kr.co.presentation.feature.auth.navigation.WelcomeRoute
 import kr.co.presentation.main.navigation.MainRoute
+import kr.co.presentation.main.preview.LoadStatePreviewDataProvider
 import kr.co.presentation.main.viewmodel.MainActivitySideEffect
 import kr.co.presentation.main.viewmodel.MainActivityViewModel
-import kr.co.presentation.main.viewmodel.StartDestination
 import kr.co.presentation.navigation.host.AppNaveGraph
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
@@ -50,24 +65,98 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                when (state.startDestination) {
-                    is StartDestination.Welcome -> {
+                LoadStateContent(
+                    loadState = state.loginLoadState,
+                    loading = { LoadingContent() },
+                    error = { error ->
                         AppNaveGraph(
                             navController = navController,
                             startDestination = WelcomeRoute
                         )
-                    }
-
-                    is StartDestination.Main -> {
-                        AppNaveGraph(
-                            navController = navController,
-                            startDestination = MainRoute
-                        )
-                    }
-
-                    is StartDestination.Splash -> {}
+                    },
+                ) {
+                    AppNaveGraph(
+                        navController = navController,
+                        startDestination = MainRoute
+                    )
                 }
             }
         }
+    }
+}
+
+@Composable
+fun LoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun PreviewUnInitializedContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = stringResource(R.string.preview_uninitialized_content))
+    }
+}
+
+@Composable
+private fun PreviewLoadingContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = stringResource(R.string.preview_loading_content))
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun PreviewWelcomeScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.errorContainer),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = stringResource(R.string.preview_welcome_content))
+    }
+}
+
+@Composable
+private fun PreviewMainScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = stringResource(R.string.preview_main_content))
+    }
+}
+
+@Preview(showBackground = true, locale = "ko")
+@Composable
+private fun MainActivityLoadStateContentPreviewPreview(
+    @PreviewParameter(LoadStatePreviewDataProvider::class) loadState: LoadState<Unit>
+) {
+    MinaryTheme {
+        LoadStateContent(
+            loadState = loadState,
+            uninitialized = { PreviewUnInitializedContent() },
+            loading = { PreviewLoadingContent() },
+            error = { PreviewWelcomeScreen() },
+            content = {
+                PreviewMainScreen()
+            }
+        )
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/main/screen/MainScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/screen/MainScreen.kt
@@ -163,7 +163,7 @@ private fun MainContentPreview() {
                     .padding(innerPadding),
                 contentAlignment = Alignment.Center
             ) {
-                Text(stringResource(R.string.preview_mode_main_content_area))
+                Text(stringResource(R.string.preview_main_content))
             }
         }
     }

--- a/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainActivityViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/main/viewmodel/MainActivityViewModel.kt
@@ -7,7 +7,9 @@ import kr.co.domain.feature.auth.exception.AuthException
 import kr.co.domain.feature.auth.usecase.IsUserLoggedInUseCase
 import kr.co.domain.feature.diary.usecase.SyncDiaryUseCase
 import kr.co.presentation.R
+import kr.co.presentation.common.extension.safeCall
 import kr.co.presentation.common.model.UiText
+import kr.co.presentation.common.state.LoadState
 import kr.co.presentation.feature.auth.mapper.UserUiModelMapper.toUserUiModel
 import kr.co.presentation.feature.auth.model.UserUiModel
 import org.orbitmvi.orbit.ContainerHost
@@ -19,62 +21,51 @@ import javax.inject.Inject
 
 
 @Immutable
-sealed interface StartDestination {
-    object Splash : StartDestination
-    object Welcome : StartDestination
-    object Main : StartDestination
-}
-
-@Immutable
-data class MainActivityUiState(
-    val startDestination: StartDestination = StartDestination.Splash,
-    val loginUser: UserUiModel? = UserUiModel()
+data class MainActivityState(
+    val loginLoadState: LoadState<UserUiModel> = LoadState.Uninitialized,
 )
 
 @Immutable
 sealed interface MainActivitySideEffect {
-    data class ShowMsg(val uiText: UiText) : MainActivitySideEffect // 오류 메시지 표시
+    data class ShowMsg(val uiText: UiText) : MainActivitySideEffect
 }
 
 @HiltViewModel
 class MainActivityViewModel @Inject constructor(
     private val isUserLoggedInUseCase: IsUserLoggedInUseCase,
     private val syncDiaryUseCase: SyncDiaryUseCase,
-) : ViewModel(), ContainerHost<MainActivityUiState, MainActivitySideEffect> {
+) : ViewModel(), ContainerHost<MainActivityState, MainActivitySideEffect> {
 
-    override val container = container<MainActivityUiState, MainActivitySideEffect>(MainActivityUiState())
+    override val container =
+        container<MainActivityState, MainActivitySideEffect>(MainActivityState())
 
     init {
         checkLogin()
     }
 
     private fun checkLogin() = intent {
-        val loggedIn = isUserLoggedInUseCase()
-        loggedIn.onSuccess { user ->
+        safeCall { isUserLoggedInUseCase() }
+            .map { it.toUserUiModel() }
+            .launchAsLoadState { loadState ->
+                reduce { state.copy(loginLoadState = loadState) }
 
-            reduce {
-                state.copy(loginUser = user.toUserUiModel(), startDestination = StartDestination.Main)
-            }
-
-            syncDiaryUseCase()
-        }.onFailure { error ->
-            reduce {
-                state.copy(loginUser = null, startDestination = StartDestination.Welcome)
-            }
-
-            when(error) {
-                is AuthException.CurrentUserIsNullException -> {
-                    postSideEffect(MainActivitySideEffect.ShowMsg(UiText.StringResource(R.string.current_user_is_null)))
+                when (loadState) {
+                    is LoadState.Success -> syncDiaryUseCase()
+                    is LoadState.Error -> loadState.exception?.let { handleLoginError(it) }
+                    else -> {}
                 }
-                else -> {
-                    val uiText = error.message
-                        .takeIf { !it.isNullOrBlank() }
-                        ?.let { UiText.DynamicString(it) }
-                        ?: UiText.StringResource(R.string.unknown_error)
+            }
+    }
 
-                    postSideEffect(MainActivitySideEffect.ShowMsg(uiText))
-                }
+    private fun handleLoginError(error: Throwable) = intent {
+        val message = when (error) {
+            is AuthException.CurrentUserIsNullException -> UiText.StringResource(R.string.current_user_is_null)
+            else -> {
+                error.message
+                    ?.let { UiText.DynamicString(it) }
+                    ?: UiText.StringResource(R.string.unknown_error)
             }
         }
+        postSideEffect(MainActivitySideEffect.ShowMsg(message))
     }
 }

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -36,7 +36,12 @@
     <string name="password_not_match">비밀번호가 일치하지 않습니다</string>
     <string name="account_creation_failed">계정 생성에 실패했습니다</string>
     <string name="current_user_is_null">없는 사용자입니다</string>
-    <string name="preview_mode_main_content_area">메인 화면 (미리보기 화면)</string>
     <string name="diary_title_is_empty">일기 제목이 비어 있습니다.</string>
     <string name="diary_content_is_empty">일기 내용이 비어 있습니다</string>
+    <string name="diary_saved">일기가 저장되었습니다.</string>
+    <string name="diary_title_hint">제목</string>
+    <string name="diary_content_hint">내용</string>
+    <string name="diary_done_button">완료</string>
+    <string name="diary_edit_button">편집</string>
+    <string name="diary_delete_button_cd">일기 삭제 버튼</string>
 </resources>

--- a/presentation/src/main/res/values-ko/strings_preview.xml
+++ b/presentation/src/main/res/values-ko/strings_preview.xml
@@ -61,4 +61,10 @@
     <string name="preview_diary_content_envy">동기인 친구가 나보다 먼저 승진했다는 소식을 들었다. 축하해줘야 하는 걸 알면서도 마음 한편으로는 부러운 마음이 드는 건 어쩔 수 없다.</string>
     <string name="preview_diary_content_craving">오랫동안 준비해온 시험 결과가 내일 나온다. 이번에는 정말 합격하고 싶다. 잠도 안 오고 간절하게 기도만 하게 된다.</string>
     <string name="preview_diary_content_unknown">점심은 김치찌개, 저녁은 된장찌개를 먹었다. 오늘 할 일 목록 3가지를 처리했다.</string>
+
+    <string name="preview_uninitialized_content">초기 화면 (미리보기 화면)</string>
+    <string name="preview_loading_content">로딩 화면 (미리보기 화면)</string>
+    <string name="preview_welcome_content">에러 화면 (미리보기 화면)</string>
+    <string name="preview_retry">다시 시도</string>
+    <string name="preview_main_content">메인 화면 (미리보기 화면)</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -36,7 +36,12 @@
     <string name="password_not_match">Password does not match</string>
     <string name="account_creation_failed">Account creation failed</string>
     <string name="current_user_is_null">Current user is null</string>
-    <string name="preview_mode_main_content_area">Main Content Area (Preview Mode)</string>
     <string name="diary_title_is_empty">diary title is empty</string>
     <string name="diary_content_is_empty">diary content is empty</string>
+    <string name="diary_saved">Your diary has been saved.</string>
+    <string name="diary_title_hint">Title</string>
+    <string name="diary_content_hint">Content</string>
+    <string name="diary_done_button">Done</string>
+    <string name="diary_edit_button">Edit</string>
+    <string name="diary_delete_button_cd">Delete diary button</string>
 </resources>

--- a/presentation/src/main/res/values/strings_preview.xml
+++ b/presentation/src/main/res/values/strings_preview.xml
@@ -61,4 +61,10 @@
     <string name="preview_diary_content_envy">I heard that my friend, who joined the company at the same time as me, got promoted before me. I know I should congratulate them, but I can\'t help but feel envious on one side of my heart.</string>
     <string name="preview_diary_content_craving">The results of the exam I have been preparing for a long time will be released tomorrow. I really want to pass this time. I can\'t sleep and just pray earnestly.</string>
     <string name="preview_diary_content_unknown">I had kimchi stew for lunch and soybean paste stew for dinner. I completed 3 items on my to-do list today.</string>
+
+    <string name="preview_uninitialized_content">Uninitialized Content (Preview)</string>
+    <string name="preview_loading_content">Loading Content (Preview)</string>
+    <string name="preview_welcome_content">Welcome Content (Preview)</string>
+    <string name="preview_retry">retry</string>
+    <string name="preview_main_content">Main Content (Preview)</string>
 </resources>


### PR DESCRIPTION
## 설명
- [Feat] 네트워크 통신, 로컬 DB 연동으로 데이터를 화면에 표시하려 할 때
앱이 멈춰있지 않음을 사용자에게 피드백주기 위해, Skeleton 화면을 구성하고, 버튼 로딩 기능을 추가

## 관련 이슈
- Closes #34 

## 세부 내용
- 데이터 로딩 화면에 Skeleton 화면 구현
- 개별 기능 작동을 표시하기 위한 로딩 버튼 구현