### PR TITLE
docs: AGENTS.md 파일 업데이트

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,17 +25,18 @@
 - **Write 흐름**: UI -> UseCase -> Local DB 갱신(UI 즉시 반영) -> Sync Worker 예약 -> Remote(Firebase) 반영
 - **LWW 충돌 해결**: 동기화 기준 시간은 절대 클라이언트 기기 시간(`System.currentTimeMillis()`)을 쓰지 않는다. 반드시 `ServerTimeProvider` (TrueTime 기반)를 사용해 `lastModifiedAt`을 갱신 및 비교한다.
 
-## 3. 기술 스택 및 라이브러리 관리 규칙
+## 4. 기술 스택 및 라이브러리 관리 규칙
 - **의존성 기준 선언**: 프로젝트의 모든 기술 스택(Kotlin, Compose, Orbit MVI, Room, Firebase, WorkManager, Hilt, Gemini AI 등)은 **`gradle/libs.versions.toml`** 파일에 선언된 버전 카탈로그를 유일한 기준으로 삼는다. 새로운 라이브러리 도입 시 반드시 이 파일에 먼저 등록해야 한다.
 - **하드코딩 금지**: 각 모듈의 `build.gradle.kts`나 소스 코드 내부에 라이브러리 버전 번호를 직접 입력하는 하드코딩을 엄격히 금지한다. 모든 의존성 참조는 반드시 `libs.*` alias를 통해 버전 카탈로그와 일관성을 유지해야 한다.
 - **에러 핸들링**: `try-catch` 대신 `kotlin-result` 라이브러리를 활용한 함수형 에러 처리를 전 모듈에 적용한다.
 
-## 4. AI 코드 생성 및 프로젝트 구조
-새로운 기능 추가 시 반드시 다음 순서를 따르며, 기존 패키지나 클래스가 존재할 경우 새 패키지 생성보다 기존 구조를 우선 활용하고 확장한다.
-1. **Domain**: 계약(Contract) 우선 정의. 도메인 모델 / Repository 인터페이스 / UseCase 추가.
-2. **Data**: Entity/DTO/Mapper/DataSource/RepositoryImpl 추가 (SyncManager/Worker 포함).
-3. **Presentation**: UiModel/Mapper/State/SideEffect/Action/ViewModel/Screen/Graph 추가.
-4. **App**: Hilt binding 및 Navigation Route 등록 등 최종 조립.
+## 5. AI 코드 생성 및 프로젝트 구조
+- **주석 보존**: 기존 주석을 함부로 삭제하지 않는다. 코드 수정 시 로직 설명이나 의사결정 근거가 담긴 주석은 최대한 유지하며, 필요한 경우 보강한다.
+- **구조 우선 순위**: 새로운 기능 추가 시 반드시 다음 순서를 따르며, 기존 패키지나 클래스가 존재할 경우 새 패키지 생성보다 기존 구조를 우선 활용하고 확장한다.
+    1. **Domain**: 계약(Contract) 우선 정의. 도메인 모델 / Repository 인터페이스 / UseCase 추가.
+    2. **Data**: Entity/DTO/Mapper/DataSource/RepositoryImpl 추가 (SyncManager/Worker 포함).
+    3. **Presentation**: UiModel/Mapper/State/SideEffect/Action/ViewModel/Screen/Graph 추가.
+    4. **App**: Hilt binding 및 Navigation Route 등록 등 최종 조립.
 
 ```mermaid
 graph TD
@@ -46,3 +47,9 @@ graph TD
     app --> domain
 ```
 - **firebase-server**: 독립 배포 모듈 (클라이언트와 경로 동기화 필수)
+
+## 6. 버전 관리 및 협업 규칙 (Git & GitHub)
+- **로컬 커밋**: Git을 통해 로컬에 커밋할 때는 반드시 `.gitmessage.txt` 템플릿 파일을 참고하여 형식에 맞게 작성한다.
+- **GitHub Issue & PR**: GitHub MCP를 이용해 이슈를 관리하거나 PR을 생성할 때는 프로젝트 내 `.github/` 폴더 하위의 템플릿 파일들을 최우선으로 참조한다.
+    - 이슈: `.github/ISSUE_TEMPLATE/` (bug.md, feat.md 등)
+    - PR: `.github/pull_request_template.md`

--- a/presentation/AGENTS.md
+++ b/presentation/AGENTS.md
@@ -21,6 +21,9 @@
     - 각 `Screen`은 전용 Preview를 포함해야 하며, 다양한 상태나 복잡한 데이터가 필요한 경우 `feature/{name}/preview` 패키지에 **`{name}ScreenPreviewParameterProvider`**를 구현하여 데이터를 분리 관리한다.
 - **UDF**: 모든 Composable은 비즈니스 로직이 없는 순수 함수로 작성하며 상태 호이스팅을 준수한다.
 - **Theme**: `MinaryTheme`을 기반으로 하며, 커스텀 속성은 `MaterialTheme` 확장을 통해 접근한다.
+- **Skeleton Screen**: 데이터 로딩이 필요한 화면은 사용자 경험을 위해 Skeleton 화면을 반드시 함께 구현한다.
+    - 구현 시 `presentation/common/skeleton`에 정의된 공통 컴포넌트(`SkeletonButton`, `SkeletonIconButton`, `SkeletonSpacer`, `SkeletonText` 등)를 적극 활용한다.
+    - 참고 예시: `SkeletonDiaryPreviewContent.kt`, `SkeletonDiaryEditContent.kt`
 
 ## 3. 에러 처리 및 Mapper 규칙
 - **Error**: UseCase 실패 시 `DomainError`를 `handleDomainError` 확장 함수를 통해 `UiText`로 변환하여 노출한다.


### PR DESCRIPTION
## why
- AGENT가 일관된 commit 메세지를 작성시키기 위함
- AGENT가 일관된 GitHub 템플릿을 작성시키기 위함
- AGENT가 기준 주석을 함브로 삭제하지 못하게 하기 위함
- AGENT가 새로운 화면 개발 및 수정시 데이터 로딩이 필요한 화면에서 Skeleton 화면을 작성시키기 위함

## what
- 주석 보존 규칙 추가
- 버전 관리 규칙 추가
- Skeleton 화면 구성 규칙 추가

## impact
- minary/AGENTS.md
- presentation/AGENTS.md