### PR TITLE
fix: 상세 화면 이동 시 하단 네비게이션 바 활성화 상태 유지

### DIFF
--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/navigation/CalendarGraph.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/navigation/CalendarGraph.kt
@@ -11,31 +11,39 @@ import kr.co.presentation.navigation.MonthlyCalendarRoute
 import kr.co.presentation.navigation.YearlyCalendarRoute
 
 
-internal fun NavGraphBuilder.calenderGraph(
+import androidx.navigation.compose.navigation
+import kr.co.presentation.navigation.CalendarRoute
+import java.time.YearMonth
+
+internal fun NavGraphBuilder.calendarGraph(
     appState: MinaryAppState,
     navController: NavHostController,
 ) {
-    composable<MonthlyCalendarRoute> {
-        MonthlyCalendarScreen(
-            onYearClicked = { year ->
-                navController.navigate(YearlyCalendarRoute(year)) {
-                    launchSingleTop = true
-                    restoreState = true
-                }
-            },
-            onDayClicked = { date -> appState.navigateToDiaryPreview(date) },
-        )
-    }
+    navigation<CalendarRoute>(
+        startDestination = MonthlyCalendarRoute(YearMonth.now().year, YearMonth.now().monthValue)
+    ) {
+        composable<MonthlyCalendarRoute> {
+            MonthlyCalendarScreen(
+                onYearClicked = { year ->
+                    navController.navigate(YearlyCalendarRoute(year)) {
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                onDayClicked = { date -> appState.navigateToDiaryPreview(date) },
+            )
+        }
 
-    composable<YearlyCalendarRoute> {
-        YearlyCalendarScreen(
-            onMonthClicked = { yearMonth ->
-                navController.navigate(MonthlyCalendarRoute(yearMonth.year, yearMonth.monthValue)) {
-                    popUpTo(navController.graph.findStartDestination().id) {
-                        inclusive = true
+        composable<YearlyCalendarRoute> {
+            YearlyCalendarScreen(
+                onMonthClicked = { yearMonth ->
+                    navController.navigate(MonthlyCalendarRoute(yearMonth.year, yearMonth.monthValue)) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            inclusive = true
+                        }
                     }
                 }
-            }
-        )
+            )
+        }
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/home/navigation/HomeHost.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/home/navigation/HomeHost.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import kr.co.presentation.feature.calendar.navigation.calenderGraph
+import kr.co.presentation.feature.calendar.navigation.calendarGraph
 import kr.co.presentation.feature.dashboard.navigation.dashboardGraph
 import kr.co.presentation.feature.setting.navigation.settingsGraph
 import kr.co.presentation.feature.store.navigation.storeGraph
@@ -19,7 +19,7 @@ fun HomeHost(
     modifier: Modifier,
 ) {
     NavHost(navController, startDestination, modifier) {
-        calenderGraph(appState, navController)
+        calendarGraph(appState, navController)
         dashboardGraph(appState, navController)
         storeGraph(appState, navController)
         settingsGraph(appState, navController)

--- a/presentation/src/main/java/kr/co/presentation/feature/home/screen/HomeScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/home/screen/HomeScreen.kt
@@ -58,15 +58,14 @@ import kr.co.presentation.feature.home.preview.HomeScreenPreviewDataProvider
 import kr.co.presentation.feature.home.viewmodel.HomeAction
 import kr.co.presentation.feature.home.viewmodel.HomeScreenState
 import kr.co.presentation.feature.home.viewmodel.HomeViewModel
+import kr.co.presentation.navigation.CalendarRoute
 import kr.co.presentation.navigation.DashboardRoute
 import kr.co.presentation.navigation.MinaryAppState
-import kr.co.presentation.navigation.MonthlyCalendarRoute
-import kr.co.presentation.navigation.SettingsRoute
+import kr.co.presentation.navigation.SettingsTabRoute
 import kr.co.presentation.navigation.StoreRoute
 import kr.co.presentation.navigation.navigateIfNotCurrent
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
-import java.time.YearMonth
 
 @SuppressLint("RestrictedApi")
 @Composable
@@ -84,15 +83,10 @@ fun HomeScreen(
         snackbarHostState = snackbarHostState,
         navController = bottomNavController,
     ) { innerPadding ->
-        val currentYearMonth = YearMonth.now()
-
         HomeHost(
             appState = appState,
             navController = bottomNavController,
-            startDestination = MonthlyCalendarRoute(
-                currentYearMonth.year,
-                currentYearMonth.monthValue
-            ),
+            startDestination = CalendarRoute,
             modifier = Modifier.padding(innerPadding)
         )
     }
@@ -106,12 +100,11 @@ fun HomeContent(
     navController: NavHostController = rememberNavController(),
     content: @Composable (PaddingValues) -> Unit = {}
 ) {
-    val currentYearMonth = YearMonth.now()
     val navigationItems = remember {
         listOf(
             HomeNavigationItem(
                 R.string.calendar,
-                MonthlyCalendarRoute(currentYearMonth.year, currentYearMonth.monthValue),
+                CalendarRoute,
                 Icons.Outlined.CalendarMonth
             ),
             HomeNavigationItem(
@@ -126,7 +119,7 @@ fun HomeContent(
             ),
             HomeNavigationItem(
                 R.string.setting,
-                SettingsRoute,
+                SettingsTabRoute,
                 Icons.Outlined.Settings
             ),
         )

--- a/presentation/src/main/java/kr/co/presentation/feature/setting/navigation/SettingsGraph.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/setting/navigation/SettingsGraph.kt
@@ -3,6 +3,7 @@ package kr.co.presentation.feature.setting.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import kr.co.presentation.feature.setting.screen.ProfileDetailScreen
 import kr.co.presentation.feature.setting.screen.ProfileEditScreen
 import kr.co.presentation.feature.setting.screen.SettingsScreen
@@ -10,39 +11,44 @@ import kr.co.presentation.navigation.MinaryAppState
 import kr.co.presentation.navigation.ProfileDetailRoute
 import kr.co.presentation.navigation.ProfileEditRoute
 import kr.co.presentation.navigation.SettingsRoute
+import kr.co.presentation.navigation.SettingsTabRoute
 
 
 internal fun NavGraphBuilder.settingsGraph(
     appState: MinaryAppState,
     navController: NavHostController,
 ) {
-    composable<SettingsRoute> {
-        SettingsScreen(
-            onUserProfileClicked = {
-                navController.navigate(ProfileDetailRoute) {
-                    launchSingleTop = true
-                }
-            },
-            onSignOutSucceeded= { appState.navigateToWelcome() }
-        )
-    }
+    navigation<SettingsTabRoute>(
+        startDestination = SettingsRoute
+    ) {
+        composable<SettingsRoute> {
+            SettingsScreen(
+                onUserProfileClicked = {
+                    navController.navigate(ProfileDetailRoute) {
+                        launchSingleTop = true
+                    }
+                },
+                onSignOutSucceeded = { appState.navigateToWelcome() }
+            )
+        }
 
-    composable<ProfileDetailRoute> {
-        ProfileDetailScreen(
-            onBackClicked = { navController.popBackStack() },
-            onEditClicked = {
-                navController.navigate(ProfileEditRoute) {
-                    launchSingleTop = true
-                }
-            },
-            onNavigateToAccountDeletion = { appState.navigateToAccountDeletion() }
-        )
-    }
+        composable<ProfileDetailRoute> {
+            ProfileDetailScreen(
+                onBackClicked = { navController.popBackStack() },
+                onEditClicked = {
+                    navController.navigate(ProfileEditRoute) {
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToAccountDeletion = { appState.navigateToAccountDeletion() }
+            )
+        }
 
-    composable<ProfileEditRoute> {
-        ProfileEditScreen(
-            onBackClicked = { navController.popBackStack() },
-            onProfileUpdateSucceeded = { navController.popBackStack() }
-        )
+        composable<ProfileEditRoute> {
+            ProfileEditScreen(
+                onBackClicked = { navController.popBackStack() },
+                onProfileUpdateSucceeded = { navController.popBackStack() }
+            )
+        }
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/navigation/MinaryRoutes.kt
+++ b/presentation/src/main/java/kr/co/presentation/navigation/MinaryRoutes.kt
@@ -10,10 +10,12 @@ import kotlinx.serialization.Serializable
 @Serializable data object HomeRoute
 @Serializable data class DiaryPreviewRoute(val year: Int, val month: Int, val date: Int)
 @Serializable data class DiaryEditRoute(val year: Int, val month: Int, val date: Int, val isNewDiary: Boolean)
+@Serializable data object CalendarRoute
 @Serializable data class MonthlyCalendarRoute(val year: Int, val month: Int)
 @Serializable data class YearlyCalendarRoute(val year: Int)
 @Serializable data object DashboardRoute
 @Serializable data object StoreRoute
+@Serializable data object SettingsTabRoute
 @Serializable data object SettingsRoute
 @Serializable data object ProfileDetailRoute
 @Serializable data object ProfileEditRoute


### PR DESCRIPTION
## related issue
- closes: #52

## why
- 캘린더 및 설정 탭의 상세 화면(연간 달력, 프로필 상세 등)으로 이동 시 하단 네비게이션 바의 선택 상태가 해제되는 UI 일관성 문제 해결이 필요함

## what
- CalendarRoute, SettingsTabRoute를 추가하여 상세 화면들을 중첩 네비게이션(Nested Navigation) 구조로 계층화
- HomeScreen의 NavigationBarItem 활성 상태 판단 기준을 개별 Route에서 상위 그룹 Route로 변경
- calenderGraph -> calendarGraph 오타 수정 및 미사용 import 정리

## impact
- 상세 화면 이동 후에도 현재 머물고 있는 탭의 위치를 사용자가 시각적으로 명확히 파악할 수 있음