### PR TITLE
style: 캘린더 UI/UX 업데이트

### DIFF
--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/ActiveDay.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/ActiveDay.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
@@ -20,15 +21,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kr.co.domain.feature.emotion.model.Emotion
-import kr.co.presentation.common.extension.color
+import androidx.compose.ui.unit.sp
+import kr.co.presentation.design.ThemePreviews
 import kr.co.presentation.feature.calendar.extension.isToday
 import kr.co.presentation.feature.calendar.model.CalendarDayItem
 import kr.co.presentation.feature.diary.model.DiaryUiModel
-import kr.co.presentation.design.ThemePreviews
 import kr.co.presentation.theme.MinaryTheme
 import java.time.LocalDate
-
 
 @Composable
 fun ActiveDay(
@@ -39,11 +38,17 @@ fun ActiveDay(
 ) {
     val isToday = dayItem.isToday()
 
-    val shape = if (isToday) CircleShape else MaterialTheme.shapes.small
-    val color = if (isToday) MaterialTheme.colorScheme.primaryContainer else Color.Transparent
+    val backgroundColor = when {
+        isToday -> MaterialTheme.colorScheme.primary
+        else -> Color.Transparent
+    }
 
-    val textColor = if (isToday) MaterialTheme.colorScheme.onPrimaryContainer else MaterialTheme.colorScheme.onBackground
-    val fontWeight = if (isToday) FontWeight.Bold else FontWeight.Normal
+    val textColor = when {
+        isToday -> MaterialTheme.colorScheme.onPrimary
+        else -> MaterialTheme.colorScheme.onSurface
+    }
+
+    val fontWeight = if (isToday) FontWeight.Bold else FontWeight.Medium
 
     Column(
         modifier = modifier
@@ -52,33 +57,45 @@ fun ActiveDay(
                 enabled = (onClick != null),
                 onClick = { onClick?.invoke(dayItem) }
             )
-            .clip(shape)
-            .background(color),
+            .padding(4.dp)
+            .clip(CircleShape)
+            .background(backgroundColor),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
             text = "${dayItem.date.dayOfMonth}",
-            style = MaterialTheme.typography.labelSmall,
+            fontSize = 14.sp,
             color = textColor,
             fontWeight = fontWeight,
         )
 
-        if (diary != null)
+        if (diary != null) {
             Box(
                 modifier = Modifier
-                    .padding(6.dp)
-                    .size(6.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.primary, CircleShape)
-                    /*.background(diary.emotion.color, CircleShape)*/
+                    .padding(top = 2.dp)
+                    .size(4.dp)
+                    .background(if (isToday) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary, CircleShape)
             )
-        else
-            Spacer(
-                modifier = Modifier
-                    .padding(6.dp)
-                    .size(6.dp)
+        } else {
+            Spacer(modifier = Modifier.height(6.dp))
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun ActiveDayTodayPreview() {
+    MinaryTheme {
+        Surface(color = MaterialTheme.colorScheme.background) {
+            ActiveDay(
+                modifier = Modifier.size(48.dp),
+                dayItem = CalendarDayItem(
+                    isCurrentMonth = true,
+                ),
+                diary = DiaryUiModel(),
             )
+        }
     }
 }
 
@@ -87,14 +104,14 @@ fun ActiveDay(
 private fun ActiveDayPreview() {
     MinaryTheme {
         Surface(color = MaterialTheme.colorScheme.background) {
+            val yesterday = LocalDate.now().minusDays(1)
             ActiveDay(
-                modifier = Modifier.size(46.dp),
+                modifier = Modifier.size(48.dp),
                 dayItem = CalendarDayItem(
-                    date = LocalDate.now(),
                     isCurrentMonth = true,
+                    date = yesterday
                 ),
-                /*diary = DiaryUiModel(emotion = Emotion.TRIUMPH),*/
-                diary = DiaryUiModel(),
+                diary = DiaryUiModel().copy(date = yesterday),
             )
         }
     }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/InactiveDay.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/InactiveDay.kt
@@ -1,11 +1,10 @@
 package kr.co.presentation.feature.calendar.composable
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -13,14 +12,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import kr.co.presentation.feature.calendar.model.CalendarDayItem
+import androidx.compose.ui.unit.sp
 import kr.co.presentation.design.ThemePreviews
+import kr.co.presentation.feature.calendar.model.CalendarDayItem
 import kr.co.presentation.theme.MinaryTheme
-
 
 @Composable
 fun InactiveDay(
@@ -28,21 +24,17 @@ fun InactiveDay(
     dayItem: CalendarDayItem,
 ) {
     Column(
-        modifier = modifier
-            .aspectRatio(1f)
-            .clip(MaterialTheme.shapes.small)
-            .background(color = Color.Transparent),
+        modifier = modifier.aspectRatio(1f),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
         Text(
             text = "${dayItem.date.dayOfMonth}",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.outline,
-            fontWeight = FontWeight.Normal,
+            fontSize = 16.sp,
+            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
         )
 
-        Spacer(modifier = Modifier.padding(6.dp).size(6.dp))
+        Spacer(modifier = Modifier.height(6.dp))
     }
 }
 
@@ -52,7 +44,7 @@ private fun InactiveDayPreview() {
     MinaryTheme {
         Surface(color = MaterialTheme.colorScheme.background) {
             InactiveDay(
-                modifier = Modifier.size(46.dp),
+                modifier = Modifier.size(48.dp),
                 dayItem = CalendarDayItem(isCurrentMonth = false)
             )
         }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendarCanvas.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/composable/MonthCalendarCanvas.kt
@@ -18,14 +18,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import kr.co.presentation.design.ThemePreviews
 import kr.co.presentation.feature.calendar.extension.isToday
 import kr.co.presentation.feature.calendar.model.CalendarMonthItem
 import kr.co.presentation.feature.calendar.preview.model.CalendarMonthPreviewData
 import kr.co.presentation.feature.calendar.preview.provider.CalendarMonthPreviewDataProvider
-import kr.co.presentation.design.ThemePreviews
 import kr.co.presentation.theme.MinaryTheme
-import kr.co.presentation.theme.Blue500
-
 
 @Composable
 fun MonthCalendarCanvas(
@@ -34,11 +32,10 @@ fun MonthCalendarCanvas(
     onClick: () -> Unit = {},
 ) {
     val textMeasurer = rememberTextMeasurer()
-
     val onSurface = MaterialTheme.colorScheme.onSurface
     val primary = MaterialTheme.colorScheme.primary
+    val onPrimary = MaterialTheme.colorScheme.onPrimary
     val error = MaterialTheme.colorScheme.error
-
     val titleStyle = remember(onSurface) {
         TextStyle(
             fontSize = 18.sp,
@@ -54,7 +51,10 @@ fun MonthCalendarCanvas(
         TextStyle(fontSize = 10.sp, color = onSurface, textAlign = TextAlign.Center)
     }
     val saturdayStyle = remember {
-        TextStyle(fontSize = 10.sp, color = Blue500, textAlign = TextAlign.Center)
+        TextStyle(fontSize = 10.sp, color = primary, textAlign = TextAlign.Center)
+    }
+    val todayStyle = remember(onPrimary) {
+        TextStyle(fontSize = 10.sp, color = onPrimary, textAlign = TextAlign.Center)
     }
 
     Canvas(
@@ -67,7 +67,6 @@ fun MonthCalendarCanvas(
         //val canvasHeight = size.height
         val cellWeight = canvasWidth / 7
         //val paddingTop = 16.dp.toPx()
-
         val titleLayout = textMeasurer.measure(
             text = monthItem.yearMonth.monthValue.toString(),
             style = titleStyle
@@ -79,27 +78,35 @@ fun MonthCalendarCanvas(
                 y = 0f
             )
         )
-
         val gridStartY = titleLayout.size.height + 4.dp.toPx()
 
         monthItem.days.forEachIndexed { index, dayItem ->
             val row = index / 7
             val col = index % 7
-
             val xPos = col * cellWeight
             val yPos = gridStartY + (row * cellWeight)
-
             val currentStyle = when (col) {
                 0 -> sundayStyle
                 6 -> saturdayStyle
                 else -> dayStyle
             }
+
             val dayText = when (dayItem.isCurrentMonth) {
                 true -> dayItem.date.dayOfMonth.toString()
                 false -> ""
             }
 
-            val dayTextLayout = textMeasurer.measure(dayText, currentStyle)
+            val today = dayItem.isCurrentMonth && dayItem.isToday()
+            if (today) {
+                drawCircle(
+                    color = primary,
+                    radius = cellWeight / 2,
+                    center = Offset(x = xPos + cellWeight / 2, y = yPos + cellWeight / 2)
+                )
+            }
+
+            val dayTextLayout =
+                textMeasurer.measure(dayText, if (today) todayStyle else currentStyle)
             drawText(
                 textLayoutResult = dayTextLayout,
                 topLeft = Offset(
@@ -107,14 +114,6 @@ fun MonthCalendarCanvas(
                     y = yPos + (cellWeight - dayTextLayout.size.height) / 2
                 )
             )
-
-            if (dayItem.isCurrentMonth && dayItem.isToday()) {
-                drawCircle(
-                    color = primary.copy(alpha = 0.3f),
-                    radius = cellWeight / 2,
-                    center = Offset(x = xPos + cellWeight / 2, y = yPos + cellWeight / 2)
-                )
-            }
         }
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/navigation/CalendarGraph.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/navigation/CalendarGraph.kt
@@ -1,18 +1,17 @@
 package kr.co.presentation.feature.calendar.navigation
 
+
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
 import kr.co.presentation.feature.calendar.screen.MonthlyCalendarScreen
 import kr.co.presentation.feature.calendar.screen.YearlyCalendarScreen
+import kr.co.presentation.navigation.CalendarRoute
 import kr.co.presentation.navigation.MinaryAppState
 import kr.co.presentation.navigation.MonthlyCalendarRoute
 import kr.co.presentation.navigation.YearlyCalendarRoute
-
-
-import androidx.navigation.compose.navigation
-import kr.co.presentation.navigation.CalendarRoute
 import java.time.YearMonth
 
 internal fun NavGraphBuilder.calendarGraph(
@@ -31,6 +30,7 @@ internal fun NavGraphBuilder.calendarGraph(
                     }
                 },
                 onDayClicked = { date -> appState.navigateToDiaryPreview(date) },
+                /*onNavigateToEdit = { date, isNewDiary -> appState.navigateToDiaryEdit(date, isNewDiary) }*/
             )
         }
 
@@ -42,7 +42,8 @@ internal fun NavGraphBuilder.calendarGraph(
                             inclusive = true
                         }
                     }
-                }
+                },
+                onBack = { navController.popBackStack() }
             )
         }
     }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/MonthlyCalendarScreen.kt
@@ -3,20 +3,42 @@ package kr.co.presentation.feature.calendar.screen
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHost
@@ -31,23 +53,31 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
+import coil.compose.AsyncImage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kr.co.domain.feature.diary.model.SyncStatus
+import kr.co.domain.feature.emotion.model.Emotion
 import kr.co.presentation.R
 import kr.co.presentation.common.composable.stringArrayResource
+import kr.co.presentation.common.extension.color
 import kr.co.presentation.common.extension.getString
+import kr.co.presentation.common.extension.resId
 import kr.co.presentation.design.ThemePreviews
 import kr.co.presentation.feature.calendar.composable.ActiveDay
 import kr.co.presentation.feature.calendar.composable.InactiveDay
@@ -57,11 +87,13 @@ import kr.co.presentation.feature.calendar.preview.provider.CalendarMonthItemPre
 import kr.co.presentation.feature.calendar.viewmodel.MonthlyCalendarAction
 import kr.co.presentation.feature.calendar.viewmodel.MonthlyCalendarSideEffect
 import kr.co.presentation.feature.calendar.viewmodel.MonthlyCalendarViewModel
+import kr.co.presentation.feature.diary.model.DiaryUiModel
 import kr.co.presentation.theme.MinaryTheme
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 import java.time.LocalDate
 import java.time.YearMonth
+import java.time.format.DateTimeFormatter
 
 @Composable
 fun MonthlyCalendarScreen(
@@ -111,7 +143,8 @@ fun MonthlyCalendarScreen(
         snackbarHostState = snackbarHostState,
         monthItems = monthItems,
         pagerState = pagerState,
-        onAction = { action -> viewModel.handleAction(action) }
+        onAction = viewModel::handleAction,
+        onDayClicked = onDayClicked
     )
 }
 
@@ -126,8 +159,10 @@ fun MonthlyCalendarContent(
         pageCount = { monthItems.itemCount },
     ),
     onAction: (MonthlyCalendarAction) -> Unit = {},
+    onDayClicked: (LocalDate) -> Unit = {},
 ) {
     val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(syncStatus) {
         if (syncStatus == SyncStatus.FAILED) {
@@ -144,23 +179,183 @@ fun MonthlyCalendarContent(
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        topBar = { MonthlyCalendarTopBar(yearMonth = yearMonth, onAction = onAction) },
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-    ) { paddingValues ->
-
-        Box(modifier = Modifier
-            .fillMaxSize()
-            .padding(paddingValues)) {
-
-            CalendarPager(
-                modifier = Modifier.fillMaxSize(),
-                pagerState = pagerState,
-                monthItems = monthItems,
-                onAction = onAction,
+        containerColor = MaterialTheme.colorScheme.background,
+        topBar = {
+            MonthlyCalendarTopBar(
+                yearMonth = yearMonth,
+                onPreviousMonth = {
+                    coroutineScope.launch {
+                        if (pagerState.currentPage + 1 < monthItems.itemCount) {
+                            pagerState.animateScrollToPage(pagerState.currentPage + 1)
+                        }
+                    }
+                },
+                onNextMonth = {
+                    coroutineScope.launch {
+                        if (pagerState.currentPage - 1 >= 0) {
+                            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                        }
+                    }
+                },
+                onAction = onAction
             )
-
-            SyncProgressOverlay(syncStatus = syncStatus)
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        floatingActionButton = {
+            FloatingActionButton(
+                onClick = { onDayClicked(LocalDate.now()) },
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                shape = CircleShape,
+            ) {
+                Icon(Icons.Default.Edit, contentDescription = null)
+            }
         }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .background(
+                        MaterialTheme.colorScheme.surface,
+                        RoundedCornerShape(12.dp)
+                    )
+                    .border(
+                        1.dp,
+                        MaterialTheme.colorScheme.outline.copy(alpha = 0.8f),
+                        RoundedCornerShape(12.dp)
+                    )
+                    .padding(16.dp)
+            ) {
+                CalendarPager(
+                    modifier = Modifier.fillMaxWidth(),
+                    pagerState = pagerState,
+                    monthItems = monthItems,
+                    onAction = onAction,
+                )
+            }
+            // Today's Diary Section
+            val today = LocalDate.now()
+            val todayDayItem =
+                monthItems.itemSnapshotList.find { it?.yearMonth == YearMonth.from(today) }
+                    ?.days?.find { it.date == today }
+            val diary = todayDayItem?.diary
+
+            if (diary != null) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                ) {
+                    Text(
+                        text = stringResource(R.string.calendar_todays_diary_label),
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onBackground,
+                        modifier = Modifier.padding(start = 4.dp, bottom = 16.dp)
+                    )
+
+                    DiarySummaryCard(diary = diary, onClick = { onDayClicked(today) })
+                }
+            }
+
+            Spacer(modifier = Modifier.height(100.dp))
+        }
+
+        SyncProgressOverlay(syncStatus = syncStatus)
+    }
+}
+
+@Composable
+private fun DiarySummaryCard(diary: DiaryUiModel, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.3.dp)
+    ) {
+        Column {
+            if (diary.imageUrls.isNotEmpty()) {
+                AsyncImage(
+                    model = diary.imageUrls.first(),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(130.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = diary.date.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+
+                    if (diary.emotions.isNotEmpty()) {
+                        EmotionTag(emotion = diary.emotions.first())
+                    }
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = diary.title,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = MaterialTheme.colorScheme.onSurface,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = diary.content,
+                    fontSize = 14.sp,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 22.sp
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmotionTag(emotion: Emotion) {
+    Row(
+        modifier = Modifier
+            .background(
+                MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.5f),
+                RoundedCornerShape(9999.dp)
+            )
+            .padding(horizontal = 12.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(12.dp)
+                .background(emotion.color, CircleShape)
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = stringResource(emotion.resId),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            color = MaterialTheme.colorScheme.onTertiaryContainer
+        )
     }
 }
 
@@ -184,30 +379,66 @@ private fun SyncProgressOverlay(syncStatus: SyncStatus) {
 @Composable
 private fun MonthlyCalendarTopBar(
     yearMonth: YearMonth,
+    onPreviousMonth: () -> Unit,
+    onNextMonth: () -> Unit,
     onAction: (MonthlyCalendarAction) -> Unit = {},
 ) {
-    Column {
-        Text(
-            text = "${yearMonth.year}",
-            modifier = Modifier
-                .padding(16.dp)
-                .clickable { onAction(MonthlyCalendarAction.YearClicked(yearMonth.year)) }
-        )
-
-        val months = stringArrayResource(R.array.months)
-        val monthText = months[yearMonth.monthValue - 1]
-
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surface,
+            )
+            .height(64.dp)
+            .border(width = 1.dp, color = MaterialTheme.colorScheme.outline.copy(alpha = 0.05f))
+            .padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.Absolute.SpaceBetween,
+            modifier = Modifier.weight(1f),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
         ) {
-            Text(text = monthText, modifier = Modifier.padding(16.dp))
+            IconButton(onClick = onPreviousMonth) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                    contentDescription = null,
+                    tint = Color(0xFF64748B)
+                )
+            }
 
             Text(
+                text = yearMonth.format(DateTimeFormatter.ofPattern("MMMM yyyy")),
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.clickable { onAction(MonthlyCalendarAction.YearClicked(yearMonth.year)) }
+            )
+
+            IconButton(onClick = onNextMonth) {
+                Icon(
+                    Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = Color(0xFF64748B)
+                )
+            }
+        }
+
+        OutlinedButton(
+            onClick = { onAction(MonthlyCalendarAction.TodayClicked) },
+            modifier = Modifier.padding(end = 8.dp),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(
+                width = 1.dp,
+                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)
+            ),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+        ) {
+            Text(
                 text = stringResource(R.string.today),
-                modifier = Modifier
-                    .padding(16.dp)
-                    .clickable { onAction(MonthlyCalendarAction.TodayClicked) },
+                fontSize = 14.sp,
+                fontWeight = FontWeight.Bold
             )
         }
     }
@@ -225,10 +456,10 @@ private fun WeekdayHeader() {
     ) {
         weekday.forEach { day ->
             Text(
-                text = day,
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                text = day.uppercase(),
+                fontSize = 12.sp,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary,
                 modifier = Modifier.weight(1f),
                 textAlign = TextAlign.Center
             )
@@ -263,9 +494,10 @@ private fun CalendarPager(
                     modifier = Modifier.weight(1f),
                     dayItem = dayItem,
                     diary = dayItem.diary,
-                ) { day -> onAction(MonthlyCalendarAction.DayClicked(day)) }
+                    onClick = { onAction(MonthlyCalendarAction.DayClicked(it)) }
+                )
             else
-                InactiveDay(modifier = Modifier.weight(1f), dayItem)
+                InactiveDay(modifier = Modifier.weight(1f), dayItem = dayItem)
         }
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/screen/YearlyCalendarScreen.kt
@@ -1,19 +1,28 @@
 package kr.co.presentation.feature.calendar.screen
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -27,11 +36,14 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
@@ -40,7 +52,6 @@ import androidx.paging.compose.itemContentType
 import androidx.paging.compose.itemKey
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kr.co.presentation.R
@@ -66,6 +77,7 @@ import kotlin.math.abs
 @Composable
 fun YearlyCalendarScreen(
     onMonthClicked: (YearMonth) -> Unit,
+    onBack: () -> Unit = {},
     viewModel: YearlyCalendarViewModel = hiltViewModel()
 ) {
     val state by viewModel.collectAsState()
@@ -114,9 +126,7 @@ fun YearlyCalendarScreen(
         when (sideEffect) {
             is YearlyCalendarSideEffect.ScrollToInitialPosition -> {
                 snapshotFlow { calendarItems.itemCount }
-                    .distinctUntilChanged()
-                    .filter { itemCount -> itemCount > 0 }
-                    .first()
+                    .distinctUntilChanged().first { itemCount -> itemCount > 0 }
                     .let { pagingItemCount ->
                         gridState.scrollToItem(pagingItemCount - 1)
                     }
@@ -136,7 +146,8 @@ fun YearlyCalendarScreen(
         calendarItems = calendarItems,
         gridState = gridState,
         snackbarHostState = snackbarHostState,
-        onAction = viewModel::handleAction
+        onAction = viewModel::handleAction,
+        onBack = onBack
     )
 }
 
@@ -147,15 +158,17 @@ fun YearlyCalendarContent(
     gridState: LazyGridState = rememberLazyGridState(),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onAction: (YearlyCalendarAction) -> Unit = {},
+    onBack: () -> Unit = {}
 ) {
     Scaffold(
         modifier = Modifier.fillMaxSize(),
-        containerColor = MaterialTheme.colorScheme.background,
+        containerColor = MaterialTheme.colorScheme.surface,
         topBar = {
             YearlyCalendarTopBar(
                 modifier = Modifier.fillMaxWidth(),
                 year = year,
                 onAction = onAction,
+                onBack = onBack
             )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) }
@@ -176,27 +189,47 @@ private fun YearlyCalendarTopBar(
     modifier: Modifier = Modifier,
     year: Year = Year.now(),
     onAction: (YearlyCalendarAction) -> Unit = {},
+    onBack: () -> Unit = {}
 ) {
     Box(
-        modifier = modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+        modifier = modifier
+            .background(MaterialTheme.colorScheme.surface)
+            .height(64.dp)
+            .padding(horizontal = 4.dp),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            modifier = Modifier.align(Alignment.CenterStart),
-            text = "${year.value}",
-            style = MaterialTheme.typography.headlineMedium,
-            fontWeight = FontWeight.Bold,
-            color = if (year.isCurrentYear()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
-        )
+        IconButton(
+            onClick = onBack,
+            modifier = Modifier.align(Alignment.CenterStart)
+        ) {
+            Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null, tint = Color(0xFF64748B))
+        }
 
         Text(
-            text = stringResource(R.string.today),
-            style = MaterialTheme.typography.titleMedium,
+            text = "${year.value}",
+            fontSize = 20.sp,
             fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.primary,
+            color = MaterialTheme.colorScheme.onSurface,
+            textAlign = TextAlign.Center
+        )
+
+        OutlinedButton(
+            onClick = { onAction(YearlyCalendarAction.TodayClicked) },
             modifier = Modifier
                 .align(Alignment.CenterEnd)
-                .clickable { onAction(YearlyCalendarAction.TodayClicked) }
-        )
+                .padding(end = 12.dp),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(width = 1.dp, color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f)),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+        ) {
+            Text(
+                text = stringResource(R.string.today),
+                fontSize = 14.sp,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }
 
@@ -212,8 +245,8 @@ private fun CalendarGrid(
         state = gridState,
         columns = GridCells.Fixed(3),
         contentPadding = PaddingValues(16.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {
         items(
             count = calendarItems.itemCount,
@@ -234,13 +267,15 @@ private fun CalendarGrid(
                 val item = calendarItems[index] ?: return@items
                 when (item) {
                     is CalendarYearItem -> YearHeader(item)
-                    is CalendarMonthItem -> MonthCalendarCanvas(
-                        modifier = Modifier
-                            .aspectRatio(1f)
-                            .padding(4.dp),
-                        monthItem = item,
-                        onClick = { onAction(YearlyCalendarAction.MonthClicked(item.yearMonth)) }
-                    )
+                    is CalendarMonthItem -> {
+                        MonthCalendarCanvas(
+                            modifier = Modifier
+                                .aspectRatio(1f)
+                                .padding(4.dp),
+                            monthItem = item,
+                            onClick = { onAction(YearlyCalendarAction.MonthClicked(item.yearMonth)) }
+                        )
+                    }
                 }
             }
         }
@@ -249,15 +284,20 @@ private fun CalendarGrid(
 
 @Composable
 private fun YearHeader(yearItem: CalendarYearItem) {
-    Text(
-        text = "${yearItem.year.value}",
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(vertical = 16.dp),
-        style = MaterialTheme.typography.headlineSmall,
-        fontWeight = FontWeight.Bold,
-        color = if (yearItem.isCurrentYear()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
-    )
+            .padding(vertical = 16.dp)
+            .background(MaterialTheme.colorScheme.surface, RoundedCornerShape(8.dp))
+            .padding(vertical = 8.dp, horizontal = 4.dp)
+    ) {
+        Text(
+            text = "${yearItem.year.value}",
+            fontSize = 20.sp,
+            fontWeight = FontWeight.Bold,
+            color = if (yearItem.isCurrentYear()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+        )
+    }
 }
 
 @ThemePreviews

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/MonthlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/MonthlyCalendarViewModel.kt
@@ -21,6 +21,7 @@ import kr.co.domain.feature.diary.usecase.GetDiaryChangeEventUseCase
 import kr.co.domain.feature.diary.usecase.sync.GetMonthSyncStatusStreamUseCase
 import kr.co.domain.feature.diary.usecase.sync.RequestMonthSyncUseCase
 import kr.co.domain.infra.network.usecase.GetNetworkStatusStreamUseCase
+import kr.co.presentation.R
 import kr.co.presentation.common.model.UiText
 import kr.co.presentation.feature.calendar.mapper.CalendarItemMapper.toCalendarMonthItem
 import kr.co.presentation.feature.calendar.model.CalendarDayItem
@@ -154,7 +155,7 @@ class MonthlyCalendarViewModel @Inject constructor(
         when (action) {
             is MonthlyCalendarAction.VisibleMonthChanged -> updateVisibleMonth(action.newVisibleYearMonth)
             is MonthlyCalendarAction.YearClicked -> yearClicked(action.year)
-            is MonthlyCalendarAction.DayClicked -> dayClicked(action.dayItem.date)
+            is MonthlyCalendarAction.DayClicked -> dayClicked(action.dayItem)
             is MonthlyCalendarAction.TodayClicked -> todayClicked()
             is MonthlyCalendarAction.RetrySyncClicked -> retrySync()
         }
@@ -175,10 +176,6 @@ class MonthlyCalendarViewModel @Inject constructor(
         postSideEffect(MonthlyCalendarSideEffect.YearClicked(year))
     }
 
-    private fun dayClicked(date: LocalDate) = intent {
-        postSideEffect(MonthlyCalendarSideEffect.DayClicked(date))
-    }
-
     private fun todayClicked() = intent {
         val currentYearMonth = YearMonth.now()
         val refreshKey = System.currentTimeMillis()
@@ -190,5 +187,14 @@ class MonthlyCalendarViewModel @Inject constructor(
         savedStateHandle[KEY_REFRESH_KEY] = refreshKey
 
         postSideEffect(MonthlyCalendarSideEffect.ScrollToToday)
+    }
+
+    private fun dayClicked(dayItem: CalendarDayItem) = intent {
+        val today = LocalDate.now()
+        if (dayItem.date.isAfter(today)) {
+            postSideEffect(MonthlyCalendarSideEffect.ShowMessage(UiText.StringResource(R.string.diary_future_date_limit_message)))
+        } else {
+            postSideEffect(MonthlyCalendarSideEffect.DayClicked(dayItem.date))
+        }
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/YearlyCalendarViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/calendar/viewmodel/YearlyCalendarViewModel.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.flow.map
 import kr.co.domain.feature.calendar.usecase.GetCalendarYearUseCase
 import kr.co.presentation.R
 import kr.co.presentation.common.model.UiText
-import kr.co.presentation.feature.calendar.extension.isAfterCurrentYearMonth
 import kr.co.presentation.feature.calendar.mapper.CalendarItemMapper.toCalendarMonthItem
 import kr.co.presentation.feature.calendar.mapper.insertYearSeparators
 import kr.co.presentation.feature.calendar.model.CalendarGridItem
@@ -30,7 +29,6 @@ import org.orbitmvi.orbit.viewmodel.container
 import java.time.Year
 import java.time.YearMonth
 import javax.inject.Inject
-
 
 @Immutable
 data class YearlyCalendarScreenState(
@@ -125,8 +123,9 @@ class YearlyCalendarViewModel @Inject constructor(
     }
 
     private fun monthClicked(targetYearMonth: YearMonth) = intent {
-        if (targetYearMonth.isAfterCurrentYearMonth()) {
-            postSideEffect(YearlyCalendarSideEffect.ShowMessage(UiText.StringResource(R.string.you_cannot_select_a_date_after_today)))
+        val currentYearMonth = YearMonth.now()
+        if (targetYearMonth.isAfter(currentYearMonth)) {
+            postSideEffect(YearlyCalendarSideEffect.ShowMessage(UiText.StringResource(R.string.calendar_future_month_limit_message)))
         } else {
             postSideEffect(YearlyCalendarSideEffect.MonthClicked(targetYearMonth))
         }

--- a/presentation/src/main/res/values-ko/strings.xml
+++ b/presentation/src/main/res/values-ko/strings.xml
@@ -63,7 +63,9 @@
 
     <!-- Calendar -->
     <string name="today">오늘</string>
-    <string name="you_cannot_select_a_date_after_today">오늘 이후에는 날짜를 선택할 수 없습니다</string>
+    <string name="calendar_todays_diary_label">오늘의 일기</string>
+    <string name="calendar_future_month_limit_message">이번달 이후 월 캘린더로 이동할 수 없습니다</string>
+    <string name="diary_future_date_limit_message">오늘 이후 일기를 미리 작성할 수 없습니다.</string>
 
     <!-- Diary -->
     <string name="diary_title_is_empty">일기 제목이 비어 있습니다.</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -63,7 +63,9 @@
 
     <!-- Calendar -->
     <string name="today">Today</string>
-    <string name="you_cannot_select_a_date_after_today">You cannot select a date after today</string>
+    <string name="calendar_todays_diary_label">Today\'s Diary</string>
+    <string name="calendar_future_month_limit_message">Cannot move to the monthly calendar after this month</string>
+    <string name="diary_future_date_limit_message">Cannot write a diary entry for a future date.</string>
 
     <!-- Diary -->
     <string name="diary_title_is_empty">diary title is empty</string>


### PR DESCRIPTION
## related issue
- closes: #54

## why
- 사용자 UI/UX 경험 향상을 위해 작업

## what
- MonthlyCalendarScreen 디자인 변경 및 테마 적용
- YearlyCalendarScreen 디자인 변경 및 테마 적용

## impact
- presentation 모듈의 calendar UI 전반적인 영향을 미침

## screenshots
<img width="545" height="581" alt="YearlyCalendarScreen" src="https://github.com/user-attachments/assets/287e6f93-359a-4513-b187-65b073aaa2ab" />
<img width="546" height="582" alt="MonthlyCalendarScreen" src="https://github.com/user-attachments/assets/7395458e-571e-47b7-a51e-d7e687e9cd41" />
