### PR TITLE
refactor: 로그 사용 방식 개선

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,10 +41,22 @@
     - `:core:ui:design`: Compose design system
 - 기존 패키지 원칙으로 설명 가능한 변경은 새 구조를 만들기보다 현재 구조를 확장한다.
 
+## 로그 규칙
+- Timber는 `:app`의 `AppLogger` 구현체에서만 사용하고, 실제 로그 호출시 `:core:common`의 `AppLogger` interface를 주입받아 사용한다.
+- `domain`은 Timber/Android Log에 의존하지 않는다. domain에서 로그가 꼭 필요하면 `AppLogger` interface만 의존하고, 기본 실패 문맥은 `AppResult<T>`와 `DomainError`로 전달해 `data` 또는 `presentation` 경계에서 기록한다.
+- 로그 메시지는 영어 고정 문구로 작성하고, 실패 로그는 `Failed to {동작}` 또는 `Failed to {동작}: %s` 형식을 우선한다.
+- `Throwable`이 있는 경우 `logger.e(throwable, "Failed to ...")`처럼 throwable을 첫 번째 인자로 전달해 stacktrace를 보존한다.
+- 로그 레벨은 목적별로 구분한다. `v/d`는 임시 진단과 debug 상태 추적, `i`는 드문 lifecycle/초기화 상태, `w`는 복구 가능한 비정상 상태, `e`는 실패하거나 사용자 흐름에 영향을 준 오류에 사용한다.
+- `v/d/i`는 반복 경로나 민감 데이터가 섞일 수 있는 경로에 남기지 않는다.
+- 로그 메시지에 함수명, 파일명, 라인 번호를 수동으로 넣지 않는다. debug 빌드의 Timber Tree가 호출 함수명과 소스 라인 번호를 자동으로 포함한다.
+- secret, credential, PII, 일기 본문, 이메일 주소, 원문 사용자 입력은 로그에 남기지 않는다. 필요한 경우 식별 불가능한 상태값이나 enum만 기록한다.
+- 단순 성공 흐름이나 반복 호출 경로에는 로그를 추가하지 않는다.
+
 ## 금지사항
 - 동기화 기준 시간에 기기 시간(`System.currentTimeMillis()`)을 직접 사용하지 않는다. `ServerTimeProvider` 계약을 사용한다.
 - 라이브러리 버전을 `build.gradle.kts`나 소스에 하드코딩하지 않는다. 새 의존성은 `gradle/libs.versions.toml`에 등록하고 `libs.*` alias로 참조한다.
 - 모듈 고유 책임을 다른 모듈에 편의상 추가하지 않는다. 경계가 애매하면 하위 `AGENTS.md`의 역할 정의를 먼저 확인한다.
+- `android.util.Log`, 호출부의 직접 `Timber`, `printStackTrace`, `println`을 앱 로그 용도로 사용하지 않는다.
 - raw exception이나 `Throwable`을 `domain`/`presentation` 공개 API로 노출하지 않는다. 예상 가능한 실패는 `DomainError` 값으로 표현한다.
 - 코드만 보면 알 수 있는 클래스/파일 목록을 AGENTS 문서에 장황하게 추가하지 않는다.
 
@@ -59,4 +71,6 @@
 ## 권장 검증
 - 문서 배치 확인: `find . -name AGENTS.md -print | sort`
 - 오래된 패키지/모듈 경로가 문서에 남지 않았는지 리팩토링 이력에 맞춰 검색한다. 검색어 자체를 `AGENTS.md`에 남겨 false positive를 만들지 않는다.
+- 로그 규칙 확인: `rg "android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" app data presentation domain core -g "*.kt"`
+- Timber 직접 사용 확인: `rg "Timber\\." data presentation domain core -g "*.kt"`
 - Gradle 모듈 변경 시: `./gradlew :app:assembleDebug`

--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -17,6 +17,9 @@
 ## 패키지/코드 배치 규칙
 - 앱 시작 초기화 순서는 `FirebaseApp.initializeApp` -> App Check 초기화 -> Hilt graph 준비 -> WorkManager factory 제공 순서를 유지한다.
 - application scope에서만 필요한 DI provider를 둔다.
+- Timber 초기화는 앱 시작시 `Application.onCreate()`에서 debug 빌드에만 수행하고, release 로그 수집이 필요하면 별도 정책으로 설계한다.
+- Timber 초기화와 `AppLogger` 구현체/binding은 application composition root 책임이므로 `:app`에 둔다.
+- `AppLogger` 구현은 wrapper로 인해 debug 로그의 실제 호출부 함수명과 라인 번호가 왜곡되지 않게 유지한다.
 - DI는 Constructor Injection을 우선하고, `@Binds`, `@Provides`는 필요한 경우에만 사용한다.
 - Android framework entry point와 앱 최종 설정 코드를 중심으로 유지한다.
 - Firebase 관련 Gradle plugin과 google-services 처리는 application 모듈에서 최종 적용한다.
@@ -28,9 +31,11 @@
 - RepositoryImpl, SyncManager, Worker 내부 정책, DataSource 구현을 두지 않는다.
 - feature별 비즈니스 규칙이나 UI 상태를 조립하지 않는다.
 - secret 값을 코드, log, 문서 예시에 직접 작성하지 않는다.
+- release 빌드에 Timber DebugTree를 plant하지 않는다. release 로그 수집이 필요하면 `AppLogger` 구현과 별도 Tree를 명시적으로 설계한다.
 
 ## 변경 시 체크리스트
 - 앱 초기화 순서가 바뀌면 Firebase/App Check/WorkManager/Hilt 초기화 영향 범위를 확인한다.
+- Timber Tree 또는 `AppLogger` 구현이 바뀌면 debug 로그에 실제 호출부 함수명과 소스 라인 번호가 계속 포함되는지 확인한다.
 - app-level DI가 추가되면 해당 provider가 정말 application composition 책임인지 확인한다.
 - UI shell 이동은 `:presentation`의 책임 경계 안에서만 허용한다.
 - release/debug 설정 변경 시 Firebase, App Check, signing, BuildConfig 노출 범위를 함께 검증한다.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
 }
 
 dependencies {
+    implementation(project(":core:common"))
     implementation(project(":core:di"))
     implementation(project(":data"))
     implementation(project(":presentation"))
@@ -64,6 +65,9 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.hilt.work)
+
+    // timber
+    implementation(libs.timber)
 
     // firebase
     implementation(platform(libs.firebase.bom))
@@ -75,4 +79,6 @@ dependencies {
     implementation(libs.firebase.config)
     implementation(libs.firebase.appcheck.playintegrity)
     implementation(libs.firebase.appcheck.debug)
+
+    testImplementation(libs.junit)
 }

--- a/app/src/debug/java/kr/co/minary/di/FirebaseModule.kt
+++ b/app/src/debug/java/kr/co/minary/di/FirebaseModule.kt
@@ -33,15 +33,13 @@ object FirebaseModule {
     @Singleton
     @Provides
     fun provideFirebaseAuth(): FirebaseAuth = Firebase.auth.apply {
-        /*useEmulator(EMULATOR_HOST, AUTH_PORT)
-        Log.d(TAG, "Firebase Auth emulator connected")*/
+        /*useEmulator(EMULATOR_HOST, AUTH_PORT)*/
     }
 
     @Singleton
     @Provides
     fun provideFirebaseFirestore(): FirebaseFirestore = Firebase.firestore.apply {
-        /*useEmulator(EMULATOR_HOST, FIRESTORE_PORT)
-        Log.d(TAG, "Firebase Firestore emulator connected")*/
+        /*useEmulator(EMULATOR_HOST, FIRESTORE_PORT)*/
 
         firestoreSettings = firestoreSettings {
             setLocalCacheSettings(memoryCacheSettings { })
@@ -51,15 +49,13 @@ object FirebaseModule {
     @Singleton
     @Provides
     fun provideFirebaseFunctions(): FirebaseFunctions = Firebase.functions(REGION_SEOUL).apply {
-        /*useEmulator(EMULATOR_HOST, FUNCTIONS_PORT)
-        Log.d(TAG, "Firebase Functions emulator connected")*/
+        /*useEmulator(EMULATOR_HOST, FUNCTIONS_PORT)*/
     }
 
     @Singleton
     @Provides
     fun provideFirebaseStorage(): FirebaseStorage = Firebase.storage.apply {
-        /*useEmulator(EMULATOR_HOST, STORAGE_PORT)
-        Log.d(TAG, "Firebase Storage emulator connected")*/
+        /*useEmulator(EMULATOR_HOST, STORAGE_PORT)*/
     }
 
     @Singleton

--- a/app/src/main/java/kr/co/minary/MinaryApplication.kt
+++ b/app/src/main/java/kr/co/minary/MinaryApplication.kt
@@ -6,6 +6,8 @@ import androidx.work.Configuration
 import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
 import kr.co.minary.initializer.AppCheckInitializer
+import kr.co.minary.logging.MinaryDebugTree
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -22,6 +24,9 @@ class MinaryApplication : Application(), Configuration.Provider {
 
     override fun onCreate() {
         super.onCreate()
+        if (BuildConfig.DEBUG) {
+            Timber.plant(MinaryDebugTree())
+        }
         // FirebaseApp 초기화
         FirebaseApp.initializeApp(this)
         // AppCheck 초기화

--- a/app/src/main/java/kr/co/minary/di/MinaryAppModule.kt
+++ b/app/src/main/java/kr/co/minary/di/MinaryAppModule.kt
@@ -7,8 +7,10 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import kr.co.core.common.logging.AppLogger
 import kr.co.core.di.qualifier.GeminiApiKey
 import kr.co.minary.BuildConfig
+import kr.co.minary.logging.TimberAppLogger
 import javax.inject.Singleton
 
 @Module
@@ -18,6 +20,10 @@ abstract class MinaryAppModule {
     @Singleton
     @Binds
     abstract fun bindContext(application: Application): Context
+
+    @Singleton
+    @Binds
+    abstract fun bindAppLogger(logger: TimberAppLogger): AppLogger
 
     companion object {
 

--- a/app/src/main/java/kr/co/minary/logging/MinaryDebugTree.kt
+++ b/app/src/main/java/kr/co/minary/logging/MinaryDebugTree.kt
@@ -1,0 +1,9 @@
+package kr.co.minary.logging
+
+import timber.log.Timber
+
+class MinaryDebugTree : Timber.DebugTree() {
+
+    override fun createStackElementTag(element: StackTraceElement): String =
+        "${super.createStackElementTag(element)}.${element.methodName}:${element.lineNumber}"
+}

--- a/app/src/main/java/kr/co/minary/logging/TimberAppLogger.kt
+++ b/app/src/main/java/kr/co/minary/logging/TimberAppLogger.kt
@@ -1,0 +1,109 @@
+package kr.co.minary.logging
+
+import kr.co.core.common.logging.AppLogger
+import kr.co.minary.BuildConfig
+import timber.log.Timber
+import javax.inject.Inject
+
+class TimberAppLogger @Inject constructor() : AppLogger {
+    override fun v(message: String, vararg args: Any?) {
+        log { location, tree -> tree.v(location.formatMessage(message), *args) }
+    }
+
+    override fun d(message: String, vararg args: Any?) {
+        log { location, tree -> tree.d(location.formatMessage(message), *args) }
+    }
+
+    override fun i(message: String, vararg args: Any?) {
+        log { location, tree -> tree.i(location.formatMessage(message), *args) }
+    }
+
+    override fun w(message: String, vararg args: Any?) {
+        log { location, tree -> tree.w(location.formatMessage(message), *args) }
+    }
+
+    override fun w(throwable: Throwable, message: String, vararg args: Any?) {
+        log { location, tree -> tree.w(throwable, location.formatMessage(message), *args) }
+    }
+
+    override fun e(message: String, vararg args: Any?) {
+        log { location, tree -> tree.e(location.formatMessage(message), *args) }
+    }
+
+    override fun e(throwable: Throwable, message: String, vararg args: Any?) {
+        log { location, tree -> tree.e(throwable, location.formatMessage(message), *args) }
+    }
+
+    private fun log(block: (CallerLocation, Timber.Tree) -> Unit) {
+        val location = createCallerLocation()
+        block(location, timber(location))
+    }
+
+    private fun timber(location: CallerLocation): Timber.Tree =
+        if (BuildConfig.DEBUG) {
+            Timber.tag(location.tag)
+        } else {
+            Timber
+        }
+
+    private companion object {
+        const val DEFAULT_TAG = "Minary"
+        const val TIMBER_APP_LOGGER_CLASS_NAME = "kr.co.minary.logging.TimberAppLogger"
+        const val MINARY_DEBUG_TREE_CLASS_NAME = "kr.co.minary.logging.MinaryDebugTree"
+        const val TIMBER_PACKAGE_NAME = "timber.log."
+        const val THREAD_CLASS_NAME = "java.lang.Thread"
+        const val VM_STACK_CLASS_NAME = "dalvik.system.VMStack"
+    }
+
+    internal fun createCallerLocation(
+        stackTrace: Array<StackTraceElement> = Thread.currentThread().stackTrace,
+    ): CallerLocation =
+        stackTrace
+            .firstOrNull { it.isAppLoggerCaller() }
+            ?.toCallerLocation()
+            ?: CallerLocation(
+                className = DEFAULT_TAG,
+                methodName = "unknown",
+                lineNumber = 0,
+            )
+
+    private fun StackTraceElement.isAppLoggerCaller(): Boolean {
+        val className = className
+        return !className.isLoggerImplementationClass() &&
+                !className.startsWith(TIMBER_PACKAGE_NAME) &&
+                className != THREAD_CLASS_NAME &&
+                className != VM_STACK_CLASS_NAME
+    }
+
+    private fun String.isLoggerImplementationClass(): Boolean =
+        this == TIMBER_APP_LOGGER_CLASS_NAME ||
+            startsWith("$TIMBER_APP_LOGGER_CLASS_NAME$") ||
+            this == MINARY_DEBUG_TREE_CLASS_NAME ||
+            startsWith("$MINARY_DEBUG_TREE_CLASS_NAME$")
+
+    private fun StackTraceElement.toCallerLocation(): CallerLocation {
+        val simpleClassName = className
+            .substringAfterLast('.')
+            .substringBefore('$')
+        return CallerLocation(
+            className = simpleClassName,
+            methodName = methodName,
+            lineNumber = lineNumber,
+        )
+    }
+
+    internal data class CallerLocation(
+        private val className: String,
+        private val methodName: String,
+        private val lineNumber: Int,
+    ) {
+        val tag: String = className
+
+        fun formatMessage(message: String): String =
+            if (BuildConfig.DEBUG) {
+                "$className.$methodName():$lineNumber\n$message"
+            } else {
+                message
+            }
+    }
+}

--- a/app/src/test/java/kr/co/minary/logging/TimberAppLoggerTest.kt
+++ b/app/src/test/java/kr/co/minary/logging/TimberAppLoggerTest.kt
@@ -1,0 +1,147 @@
+package kr.co.minary.logging
+
+import android.util.Log
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import timber.log.Timber
+
+class TimberAppLoggerTest {
+
+    private val logger = TimberAppLogger()
+    private val tree = CapturingTree()
+
+    @Before
+    fun setUp() {
+        Timber.uprootAll()
+        Timber.plant(tree)
+    }
+
+    @After
+    fun tearDown() {
+        Timber.uprootAll()
+    }
+
+    @Test
+    fun debugTagUsesActualCallerForMessageLog() {
+        val expected = logFromMessageHelper("Failed to test message")
+
+        assertEquals(expected, tree.lastTag)
+        assertEquals("TimberAppLoggerTest.logFromMessageHelper():${tree.lastLineNumber}\nFailed to test message", tree.lastMessage)
+    }
+
+    @Test
+    fun debugTagUsesActualCallerForThrowableLog() {
+        val expected = logFromThrowableHelper("Failed to test throwable")
+
+        assertEquals(expected, tree.lastTag)
+        assertTrue(
+            requireNotNull(tree.lastMessage).startsWith(
+                "TimberAppLoggerTest.logFromThrowableHelper():${tree.lastLineNumber}\nFailed to test throwable",
+            ),
+        )
+    }
+
+    @Test
+    fun debugTagUsesActualCallerForAllSupportedLevels() {
+        val expectedTags = logFromLevelHelper()
+
+        assertEquals(expectedTags, tree.tags)
+    }
+
+    @Test
+    fun debugTagSkipsAndroidRuntimeStackFrames() {
+        val location = logger.createCallerLocation(
+            arrayOf(
+                StackTraceElement(
+                    "dalvik.system.VMStack",
+                    "getThreadStackTrace",
+                    "VMStack.java",
+                    -2,
+                ),
+                StackTraceElement(
+                    "java.lang.Thread",
+                    "getStackTrace",
+                    "Thread.java",
+                    1841,
+                ),
+                StackTraceElement(
+                    "kr.co.minary.logging.TimberAppLogger",
+                    "createCallerTag",
+                    "TimberAppLogger.kt",
+                    55,
+                ),
+                StackTraceElement(
+                    "kr.co.data.feature.dashboard.repository.DashboardRepositoryImpl",
+                    "getDashboard",
+                    "DashboardRepositoryImpl.kt",
+                    32,
+                ),
+            ),
+        )
+
+        assertEquals("DashboardRepositoryImpl", location.tag)
+        assertEquals("DashboardRepositoryImpl.getDashboard():32\nmessage", location.formatMessage("message"))
+    }
+
+    private fun logFromMessageHelper(message: String): String {
+        val expectedLine = Throwable().stackTrace[0].lineNumber + 1
+        logger.e(message)
+        tree.lastLineNumber = expectedLine
+        return "TimberAppLoggerTest"
+    }
+
+    private fun logFromThrowableHelper(message: String): String {
+        val expectedLine = Throwable().stackTrace[0].lineNumber + 1
+        logger.e(IllegalStateException("test"), message)
+        tree.lastLineNumber = expectedLine
+        return "TimberAppLoggerTest"
+    }
+
+    private fun logFromLevelHelper(): List<String> {
+        val expectedTags = mutableListOf<String>()
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.v("verbose message")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.d("debug message")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.i("info message")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.w("warning message")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.w(IllegalStateException("test"), "warning throwable")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.e("error message")
+
+        expectedTags += "TimberAppLoggerTest"
+        logger.e(IllegalStateException("test"), "error throwable")
+
+        return expectedTags
+    }
+
+    private class CapturingTree : Timber.Tree() {
+        val tags = mutableListOf<String>()
+        val messages = mutableListOf<String>()
+        var lastLineNumber: Int = 0
+        val lastTag: String?
+            get() = tags.lastOrNull()
+        val lastMessage: String?
+            get() = messages.lastOrNull()
+
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            assertNotNull(tag)
+            tags += requireNotNull(tag)
+            messages += message
+            assert(priority in Log.VERBOSE..Log.ASSERT)
+        }
+    }
+}

--- a/core/common/src/main/java/kr/co/core/common/extension/ConverterExtensions.kt
+++ b/core/common/src/main/java/kr/co/core/common/extension/ConverterExtensions.kt
@@ -15,7 +15,6 @@ fun String?.toLocalDate(): LocalDate? {
     return try {
         LocalDate.parse(this)
     } catch (e: DateTimeParseException) {
-        e.printStackTrace()
         null
     }
 }
@@ -29,7 +28,6 @@ fun Long?.toLocalDate(): LocalDate? {
     return try {
         LocalDate.ofEpochDay(this)
     } catch (e: Exception) {
-        e.printStackTrace()
         // LocalDate.ofEpochDay는 지원 범위를 벗어나는 Long 값에 대해 DateTimeException을 발생시킬 수 있습니다.
         null
     }

--- a/core/common/src/main/java/kr/co/core/common/extension/LogExtensions.kt
+++ b/core/common/src/main/java/kr/co/core/common/extension/LogExtensions.kt
@@ -1,7 +1,0 @@
-package kr.co.core.common.extension
-
-val Any.TAG: String
-    get() = this::class.java.simpleName.let {
-        // 최대 23자 제한
-        if (it.length > 23) it.substring(0, 23) else it
-    }

--- a/core/common/src/main/java/kr/co/core/common/logging/AppLogger.kt
+++ b/core/common/src/main/java/kr/co/core/common/logging/AppLogger.kt
@@ -1,0 +1,17 @@
+package kr.co.core.common.logging
+
+interface AppLogger {
+    fun v(message: String, vararg args: Any?)
+
+    fun d(message: String, vararg args: Any?)
+
+    fun i(message: String, vararg args: Any?)
+
+    fun w(message: String, vararg args: Any?)
+
+    fun w(throwable: Throwable, message: String, vararg args: Any?)
+
+    fun e(message: String, vararg args: Any?)
+
+    fun e(throwable: Throwable, message: String, vararg args: Any?)
+}

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -27,6 +27,9 @@
 - Firebase 예외 타입, listener registration, snapshot처럼 data 구현에 필요한 SDK value/type 사용은 허용하되, SDK singleton 인스턴스 접근은 provider로 제한한다.
 - Firebase/Room/DataStore/IO 실패는 data 내부 mapper에서 `DomainError`로 변환하고, raw exception을 domain/presentation으로 노출하지 않는다.
 - 이미 의미를 아는 내부 실패는 예외를 던지지 말고 `Err(DomainError.*)`로 반환한다.
+- 외부 연동, persistence, sync 경계에서 예외를 기록할 때는 `AppLogger`를 생성자로 주입받아 사용한다.
+- fallback이 성공해 사용자 흐름이 계속될 수 있는 data 경계 실패는 `w`, 최종 작업 실패나 sync/repository 결과 실패는 `e`를 사용한다.
+- 로그 메시지는 실패한 data 동작을 설명하는 영어 고정 문구로 작성하고, 사용자 입력값, 이메일, 일기 본문, remote payload 원문은 포함하지 않는다.
 
 ## 금지사항
 - UI 상태, Compose, ViewModel, navigation을 참조하지 않는다.
@@ -36,6 +39,7 @@
 - Coroutine Dispatcher를 직접 고정하지 않는다. `:core:di` qualifier로 주입받은 dispatcher/scope를 사용한다.
 - 외부 예외 매핑 코드를 `:core:common`으로 올리지 않는다. 구현 기술 예외 변환은 data 책임으로 유지한다.
 - PII를 로그에 남기지 않는다.
+- `android.util.Log`, 직접 `Timber`, `printStackTrace`, `println`을 앱 로그 용도로 사용하지 않는다.
 
 ## 변경 시 체크리스트
 - local schema나 DAO 영향 변경 시 mapper, migration, query 비용을 확인한다.
@@ -50,4 +54,6 @@
 - `./gradlew :data:compileDebugKotlin`
 - import 경계 확인: `rg "kr\\.co\\.presentation|androidx\\.compose" data/src/main/java`
 - Firebase SDK 직접 주입 확인: `rg ": Firebase(Auth|Firestore|Functions|Storage|RemoteConfig)[,)]" data/src/main/java -g "*.kt"`
+- 로그 규칙 확인: `rg "android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" data/src/main/java -g "*.kt"`
+- Timber 직접 사용 확인: `rg "Timber\\." data/src/main/java -g "*.kt"`
 - Firebase 경로 변경 시 `firebase-server` rules/functions와 함께 smoke check한다.

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
 }
 
 dependencies {
-    implementation(project(":core:common"))
+    api(project(":core:common"))
     implementation(project(":core:di"))
     implementation(project(":core:storage"))
     implementation(project(":core:database"))

--- a/data/src/main/java/kr/co/data/feature/account/service/FirebaseAccountService.kt
+++ b/data/src/main/java/kr/co/data/feature/account/service/FirebaseAccountService.kt
@@ -1,12 +1,11 @@
 package kr.co.data.feature.account.service
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kr.co.core.common.result.AppResult
 import com.github.michaelbull.result.coroutines.runSuspendCatching
 import com.github.michaelbull.result.map
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onErr
-import kr.co.core.common.extension.TAG
 import kr.co.data.extension.toDomainError
 import kr.co.data.feature.account.mapper.AccountMapper.toAccount
 import kr.co.data.feature.account.source.remote.AccountRemoteDataSource
@@ -18,6 +17,7 @@ import javax.inject.Singleton
 
 @Singleton
 class FirebaseAccountService @Inject constructor(
+    private val logger: AppLogger,
     private val remoteDataSource: AccountRemoteDataSource,
 ) : AccountService {
     override suspend fun createAccount(signUpInfo: SignUpInfo, joinedAt: Long): AppResult<Unit> =
@@ -33,14 +33,14 @@ class FirebaseAccountService @Inject constructor(
                 joinedAt = joinedAt,
             )
         }
-        .onErr { Log.e(TAG, "Failed to create account with profile", it) }
+        .onErr { logger.e(it, "Failed to create account with profile") }
         .mapError { it.toDomainError() }
 
     override suspend fun deleteAccount(password: String): AppResult<String> =
         runSuspendCatching {
             remoteDataSource.deleteAccount(password)
         }
-        .onErr { Log.e(TAG, "Failed to delete account", it) }
+        .onErr { logger.e(it, "Failed to delete account") }
         .mapError { it.toDomainError() }
 
     override suspend fun signIn(
@@ -50,7 +50,7 @@ class FirebaseAccountService @Inject constructor(
         runSuspendCatching {
             remoteDataSource.signIn(email, password)
         }
-        .onErr { Log.e(TAG, "Failed to sign in", it) }
+        .onErr { logger.e(it, "Failed to sign in") }
         .map { it.toAccount() }
         .mapError { it.toDomainError() }
 
@@ -58,13 +58,13 @@ class FirebaseAccountService @Inject constructor(
         runSuspendCatching {
             remoteDataSource.signOut()
         }
-        .onErr { Log.e(TAG, "Failed to sign out", it) }
+        .onErr { logger.e(it, "Failed to sign out") }
         .mapError { it.toDomainError() }
 
     override suspend fun checkEmailAvailability(email: String): AppResult<Boolean> =
         runSuspendCatching {
             remoteDataSource.checkEmailAvailability(email)
         }
-        .onErr { Log.e(TAG, "Failed to check email availability", it) }
+        .onErr { logger.e(it, "Failed to check email availability") }
         .mapError { it.toDomainError() }
 }

--- a/data/src/main/java/kr/co/data/feature/dashboard/repository/DashboardRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/feature/dashboard/repository/DashboardRepositoryImpl.kt
@@ -1,11 +1,10 @@
 package kr.co.data.feature.dashboard.repository
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kr.co.core.common.result.AppResult
 import com.github.michaelbull.result.coroutines.runSuspendCatching
 import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onErr
-import kr.co.core.common.extension.TAG
 import kr.co.data.extension.toDomainError
 import kr.co.data.feature.dashboard.mapper.DashboardMapper.toDashboard
 import kr.co.data.feature.dashboard.model.DashboardModel
@@ -19,6 +18,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DashboardRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val databaseProvider: UserDatabaseProvider,
 ) : DashboardRepository {
     companion object {
@@ -59,7 +59,7 @@ class DashboardRepositoryImpl @Inject constructor(
                 emotionCounts = emotionCounts,
             ).toDashboard()
         }
-        .onErr { Log.e(TAG, "Failed to get dashboard", it) }
+        .onErr { logger.e(it, "Failed to get dashboard") }
         .mapError { it.toDomainError() }
 
     private fun calculateLongestStreak(dates: List<LocalDate>): Int {

--- a/data/src/main/java/kr/co/data/feature/diary/repository/DiaryRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/feature/diary/repository/DiaryRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package kr.co.data.feature.diary.repository
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.coroutines.runSuspendCatching
 import com.github.michaelbull.result.fold
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.common.result.AppResult
 import kr.co.core.common.state.DiarySyncStatus
 import kr.co.core.common.state.SyncStatus
@@ -34,6 +33,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DiaryRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val diarySyncManager: DiarySyncManager,
     private val diarySyncScheduler: DiarySyncScheduler,
     private val localDataSource: DiaryLocalDataSource,
@@ -99,7 +99,7 @@ class DiaryRepositoryImpl @Inject constructor(
 
                     updatedDiary
                 }
-                .onErr { Log.e(TAG, "Failed to update diary", it) }
+                .onErr { logger.e(it, "Failed to update diary") }
                 .mapError { it.toDomainError() }
             },
             failure = { Err(it) }
@@ -133,7 +133,7 @@ class DiaryRepositoryImpl @Inject constructor(
         runSuspendCatching {
             localDataSource.getDiaryWithRelations(date)
         }
-        .onErr { Log.e(TAG, "Failed to get diary", it) }
+        .onErr { logger.e(it, "Failed to get diary") }
         .map { it?.toDiary() }
         .mapError { it.toDomainError() }
 

--- a/data/src/main/java/kr/co/data/feature/emotion/source/remote/EmotionRemoteDataSource.kt
+++ b/data/src/main/java/kr/co/data/feature/emotion/source/remote/EmotionRemoteDataSource.kt
@@ -1,8 +1,7 @@
 package kr.co.data.feature.emotion.source.remote
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import com.google.ai.client.generativeai.GenerativeModel
-import kr.co.core.common.extension.TAG
 import kr.co.core.common.extension.toEmotion
 import kr.co.domain.feature.diary.model.Diary
 import kr.co.core.common.model.Emotion
@@ -11,6 +10,7 @@ import javax.inject.Singleton
 
 @Singleton
 class EmotionRemoteDataSource @Inject constructor(
+    private val logger: AppLogger,
     private val generativeModel: GenerativeModel
 ) {
     suspend fun analysis(diary: Diary): List<Emotion> {
@@ -39,7 +39,7 @@ class EmotionRemoteDataSource @Inject constructor(
 
             return selectedEmotions.ifEmpty { listOf(Emotion.UNKNOWN) }
         } catch (e: Exception){
-            Log.e(TAG, "emotionAnalysisAi: ${e.message}")
+            logger.e(e, "Failed to analyze emotion")
             return listOf(Emotion.UNKNOWN)
         }
     }

--- a/data/src/main/java/kr/co/data/feature/profile/repository/UserProfileRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/feature/profile/repository/UserProfileRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package kr.co.data.feature.profile.repository
 
+import kr.co.core.common.logging.AppLogger
 import android.net.Uri
-import android.util.Log
 import com.github.michaelbull.result.Ok
 import kr.co.core.common.result.AppResult
 import com.github.michaelbull.result.andThen
@@ -10,7 +10,6 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onErr
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kr.co.core.common.extension.TAG
 import kr.co.data.extension.toDomainError
 import kr.co.data.feature.profile.mapper.UserProfileMapper.toUserProfile
 import kr.co.data.feature.profile.mapper.UserProfileMapper.toUserProfileProto
@@ -23,6 +22,7 @@ import java.io.File
 import javax.inject.Inject
 
 class UserProfileRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val localDataSource: UserProfileLocalDataSource,
     private val profileScheduler: UserProfileSyncScheduler,
     private val imageProcessor: ImageProcessor,
@@ -38,7 +38,7 @@ class UserProfileRepositoryImpl @Inject constructor(
             localDataSource.updateUserProfile(profile.toUserProfileProto())
             profileScheduler.scheduleProfilePush()
         }
-        .onErr { Log.e(TAG, "Failed to save user profile", it) }
+        .onErr { logger.e(it, "Failed to save user profile") }
         .mapError { it.toDomainError() }
 
     override suspend fun updateUserProfilePhoto(
@@ -61,7 +61,7 @@ class UserProfileRepositoryImpl @Inject constructor(
                 profileScheduler.scheduleProfilePhotoPush()
 
                 newProfilePhotoUrl
-            }.onErr { Log.e(TAG, "Failed to upload profile photo", it) }
+            }.onErr { logger.e(it, "Failed to upload profile photo") }
             .mapError { it.toDomainError() }
         }
     }

--- a/data/src/main/java/kr/co/data/feature/profile/source/local/UserProfileLocalDataSource.kt
+++ b/data/src/main/java/kr/co/data/feature/profile/source/local/UserProfileLocalDataSource.kt
@@ -1,12 +1,11 @@
 package kr.co.data.feature.profile.source.local
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
-import kr.co.core.common.extension.TAG
 import kr.co.core.datastore.profile.UserProfileDataStoreProvider
 import kr.co.core.datastore.proto.UserProfileProto
 import kr.co.core.datastore.proto.copy
@@ -16,6 +15,7 @@ import javax.inject.Singleton
 
 @Singleton
 class UserProfileLocalDataSource @Inject constructor(
+    private val logger: AppLogger,
     private val userProfileDataStoreProvider: UserProfileDataStoreProvider,
     private val userStorageLocalDataSource: UserStorageLocalDataSource,
 ) {
@@ -23,7 +23,7 @@ class UserProfileLocalDataSource @Inject constructor(
 
     fun getUserProfileFlow(): Flow<UserProfileProto> {
         return dataStore.data.catch {
-            Log.e(TAG, "Failed to read user profile from DataStore", it)
+            logger.e(it, "Failed to read user profile from DataStore")
             emit(UserProfileProto.getDefaultInstance())
         }
     }

--- a/data/src/main/java/kr/co/data/feature/session/repository/SessionRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/feature/session/repository/SessionRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package kr.co.data.feature.session.repository
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kr.co.core.common.result.AppResult
 import com.github.michaelbull.result.coroutines.runSuspendCatching
 import com.github.michaelbull.result.map
@@ -8,7 +8,6 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onErr
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kr.co.core.common.extension.TAG
 import kr.co.data.extension.toDomainError
 import kr.co.data.feature.session.mapper.UserSessionMapper.toUserSession
 import kr.co.data.feature.session.source.local.SessionLocalDataSource
@@ -20,6 +19,7 @@ import javax.inject.Singleton
 
 @Singleton
 class SessionRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val localDataSource: SessionLocalDataSource,
     private val remoteDataSource: SessionRemoteDataSource,
 ) : SessionRepository {
@@ -34,7 +34,7 @@ class SessionRepositoryImpl @Inject constructor(
         runSuspendCatching {
             remoteDataSource.getCurrentUser()
         }
-        .onErr { Log.e(TAG, "Failed to get current user", it) }
+        .onErr { logger.e(it, "Failed to get current user") }
         .map { it.toUserSession() }
         .mapError { it.toDomainError() }
 
@@ -42,7 +42,7 @@ class SessionRepositoryImpl @Inject constructor(
         runSuspendCatching {
             remoteDataSource.reload()
         }
-        .onErr { Log.e(TAG, "Failed to reload current user", it) }
+        .onErr { logger.e(it, "Failed to reload current user") }
         .map { it.toUserSession() }
         .mapError { it.toDomainError() }
 

--- a/data/src/main/java/kr/co/data/feature/setting/repository/UserSettingsRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/feature/setting/repository/UserSettingsRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package kr.co.data.feature.setting.repository
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import com.github.michaelbull.result.Ok
 import kr.co.core.common.result.AppResult
 import com.github.michaelbull.result.coroutines.runSuspendCatching
@@ -8,7 +8,6 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.onErr
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kr.co.core.common.extension.TAG
 import kr.co.data.extension.toDomainError
 import kr.co.data.feature.setting.mapper.UserSettingsMapper.toAppTheme
 import kr.co.data.feature.setting.mapper.UserSettingsMapper.toThemeProto
@@ -22,6 +21,7 @@ import kr.co.domain.feature.setting.sync.UserSettingsSyncScheduler
 import javax.inject.Inject
 
 class UserSettingsRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val localDataSource: UserSettingsLocalDataSource,
     private val settingsSyncScheduler: UserSettingsSyncScheduler,
 ) : UserSettingsRepository {
@@ -48,7 +48,7 @@ class UserSettingsRepositoryImpl @Inject constructor(
 
             settingsSyncScheduler.scheduleSettingsPush()
         }
-        .onErr { Log.e(TAG, "Failed to update theme preferences", it) }
+        .onErr { logger.e(it, "Failed to update theme preferences") }
         .mapError { it.toDomainError() }
 
     override fun getDiarySyncEnabledStream(): Flow<Boolean> =
@@ -69,6 +69,6 @@ class UserSettingsRepositoryImpl @Inject constructor(
             )
 
             settingsSyncScheduler.scheduleSettingsPush()
-        }.onErr { Log.e(TAG, "Failed to update diary sync enabled preferences", it) }
+        }.onErr { logger.e(it, "Failed to update diary sync enabled preferences") }
         .mapError { it.toDomainError() }
 }

--- a/data/src/main/java/kr/co/data/feature/setting/source/local/UserSettingsLocalDataSource.kt
+++ b/data/src/main/java/kr/co/data/feature/setting/source/local/UserSettingsLocalDataSource.kt
@@ -1,24 +1,24 @@
 package kr.co.data.feature.setting.source.local
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import kr.co.core.common.extension.TAG
 import kr.co.core.datastore.settings.UserSettingsDataStoreProvider
 import kr.co.core.datastore.proto.ThemeProto
 import kr.co.core.datastore.proto.UserSettingsProto
 import javax.inject.Inject
 
 class UserSettingsLocalDataSource @Inject constructor(
+    private val logger: AppLogger,
     private val provider: UserSettingsDataStoreProvider,
 ) {
     private val dataStore get() = provider.getDataStore()
 
     fun getUserSettingsFlow(): Flow<UserSettingsProto> {
         return dataStore.data.catch {
-            Log.e(TAG, "Failed to read user settings from DataStore", it)
+            logger.e(it, "Failed to read user settings from DataStore")
             emit(UserSettingsProto.getDefaultInstance())
         }
     }

--- a/data/src/main/java/kr/co/data/feature/user/source/local/UserStorageLocalDataSource.kt
+++ b/data/src/main/java/kr/co/data/feature/user/source/local/UserStorageLocalDataSource.kt
@@ -11,12 +11,14 @@ import kr.co.core.datastore.sync.UserSyncDataStoreProvider
 import kr.co.core.firebase.provider.FirebaseStorageProvider
 import kr.co.core.storage.config.LocalStoragePathProvider
 import kr.co.core.storage.provider.UserInternalStorageProvider
+import kr.co.core.common.logging.AppLogger
 import java.io.File
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class UserStorageLocalDataSource @Inject constructor(
+    private val logger: AppLogger,
     @param:ApplicationContext private val context: Context,
     private val userDatabaseProvider: UserDatabaseProvider,
     private val userProfileDataStoreProvider: UserProfileDataStoreProvider,
@@ -56,7 +58,7 @@ class UserStorageLocalDataSource @Inject constructor(
 
             Uri.fromFile(destinationFile)
         } catch (e: Exception) {
-            e.printStackTrace()
+            logger.e(e, "Failed to download user profile photo")
             null
         }
     }

--- a/data/src/main/java/kr/co/data/service/image/ImageProcessorImpl.kt
+++ b/data/src/main/java/kr/co/data/service/image/ImageProcessorImpl.kt
@@ -1,11 +1,11 @@
 package kr.co.data.service.image
 
+import kr.co.core.common.logging.AppLogger
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
-import android.util.Log
 import androidx.core.graphics.scale
 import androidx.core.net.toUri
 import androidx.exifinterface.media.ExifInterface
@@ -16,7 +16,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.domain.service.image.ImageProcessor
 import java.io.File
 import java.io.FileOutputStream
@@ -25,6 +24,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ImageProcessorImpl @Inject constructor(
+    private val logger: AppLogger,
     @param:ApplicationContext private val context: Context,
 ) : ImageProcessor {
 
@@ -75,7 +75,7 @@ class ImageProcessorImpl @Inject constructor(
 
             Ok(targetFile.absolutePath)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to resize image", e)
+            logger.e(e, "Failed to resize image")
             Err(DomainError.Unexpected)
         }
     }

--- a/data/src/main/java/kr/co/data/service/remoteconfig/RemoteConfigRepositoryImpl.kt
+++ b/data/src/main/java/kr/co/data/service/remoteconfig/RemoteConfigRepositoryImpl.kt
@@ -1,16 +1,16 @@
 package kr.co.data.service.remoteconfig
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
-import kr.co.core.common.extension.TAG
 import kr.co.core.firebase.provider.FirebaseRemoteConfigProvider
 import kr.co.data.BuildConfig
 import kr.co.domain.service.remoteconfig.repository.RemoteConfigRepository
 import javax.inject.Inject
 
 class RemoteConfigRepositoryImpl @Inject constructor(
+    private val logger: AppLogger,
     private val firebaseRemoteConfigProvider: FirebaseRemoteConfigProvider
 ) : RemoteConfigRepository {
 
@@ -37,7 +37,7 @@ class RemoteConfigRepositoryImpl @Inject constructor(
                 result = firebaseRemoteConfigProvider.fetchAndActivate().await()
             }
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to fetchAndActivate", e)
+            logger.e(e, "Failed to fetchAndActivate")
             result = false
         }
 

--- a/domain/AGENTS.md
+++ b/domain/AGENTS.md
@@ -25,12 +25,15 @@
 - kotlin-result 조합이 필요한 경우 `coroutineBinding`, `bind`, `mapError`, `onErr` 흐름을 사용한다.
 - 계약 성격은 `repository`, `sync`, `service`로 구분한다.
 - 복잡한 순수 비즈니스 계산은 Repository가 아니라 generator/service 성격의 domain logic으로 분리한다.
+- domain 내부에서는 로그를 기본적으로 직접 기록하지 않는다. 진단이 필요한 실패 문맥은 `AppResult<T>`와 `DomainError`로 표현하고 호출 계층에서 `AppLogger`로 기록한다.
+- domain에서 로그가 꼭 필요한 경우에도 Timber나 Android Log가 아니라 `:core:common`의 `AppLogger` interface만 의존한다.
 
 ## 금지사항
 - data/presentation 모델로 변환하는 mapper를 domain에 두지 않는다.
 - Firebase, Room, WorkManager 같은 구현 기술명을 domain contract에 노출하지 않는다.
 - 동기화 기준 시간에 기기 시간을 직접 사용하지 않는다. 시간은 domain service 계약을 통해 다룬다.
 - UI 문자열, Android resource id, `Context`를 domain에 넣지 않는다.
+- Timber, Android `Log`, `printStackTrace`, `println`을 앱 로그 용도로 사용하지 않는다.
 - raw exception을 domain API로 노출하지 않는다. 실패는 `AppResult<Value>`로 표현한다.
 - domain 전용 exception class를 공개 실패 계약으로 만들지 않는다.
 
@@ -43,4 +46,5 @@
 ## 권장 검증
 - `./gradlew :domain:test`
 - import 경계 확인: `rg "android\\.|androidx\\.compose|Firebase|Room|WorkManager|DataStore" domain/src/main/java`
+- 로그 경계 확인: `rg "Timber|android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" domain/src/main/java -g "*.kt"`
 - contract 변경 시 `./gradlew :data:compileDebugKotlin :presentation:compileDebugKotlin`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ kotlin-result = "2.3.1"
 truetime = "3.5"
 exifinterface = "1.4.2"
 lottie = "6.7.1"
+timber = "5.0.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -126,6 +127,9 @@ androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterfa
 
 #lottie
 lottie-compose = { module = "com.airbnb.android:lottie-compose", version.ref = "lottie" }
+
+#timber
+timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/presentation/AGENTS.md
+++ b/presentation/AGENTS.md
@@ -27,6 +27,9 @@
 - `Screen(viewModel = ...)`과 state 기반 `Content`를 분리해 preview/testability를 유지한다.
 - 화면 로딩 상태를 나타낼때 `:core:ui:common` load의 파일과, `:core:ui:design`의 skeleton/loading component를 우선 사용한다.
 - 에러 메시지는 화면별 side effect에서 `UiText.StringResource`를 우선 사용한다.
+- ViewModel에서 예상 밖 실패를 기록할 때는 `AppLogger`를 생성자로 주입받아 사용한다.
+- 사용자가 재시도할 수 있거나 UI fallback으로 복구되는 실패는 `w`, 화면 전환/저장/계정 흐름 실패는 `e`를 사용한다.
+- 로그 메시지는 사용자에게 보여줄 문구가 아니라 개발자 진단용 영어 고정 문구로 작성한다. 사용자 입력값, 이메일, 일기 본문, UI 텍스트 원문은 포함하지 않는다.
 
 ## 금지사항
 - ViewModel에서 RepositoryImpl, DAO, DataSource, Firebase SDK를 직접 호출하지 않는다.
@@ -34,6 +37,7 @@
 - feature 화면이 다른 feature의 내부 화면/component를 직접 참조하지 않는다.
 - 문자열, 사용자 메시지, 에러 문구를 하드코딩하지 않는다.
 - PII를 로그, snackbar, 에러 메시지에 노출하지 않는다.
+- `android.util.Log`, 직접 `Timber`, `printStackTrace`, `println`을 앱 로그 용도로 사용하지 않는다.
 - `DomainError.Unexpected` 처리 시 raw cause나 `Throwable`을 로그, 상태, side effect로 노출하지 않는다.
 - State를 `reduce` 밖에서 직접 변경하지 않는다. Navigation, snackbar, toast는 SideEffect로 처리한다.
 
@@ -48,5 +52,7 @@
 ## 권장 검증
 - `./gradlew :presentation:compileDebugKotlin`
 - import 경계 확인: `rg "kr\\.co\\.data|com\\.google\\.firebase|kr\\.co\\.minary" presentation/src/main/java`
+- 로그 규칙 확인: `rg "android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" presentation/src/main/java -g "*.kt"`
+- Timber 직접 사용 확인: `rg "Timber\\." presentation/src/main/java -g "*.kt"`
 - 화면 구조 확인: `find presentation/src/main/java/kr/co/presentation/feature -maxdepth 4 -type d | sort`
 - UI root 변경 시 `./gradlew :app:assembleDebug`

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -59,7 +59,7 @@ composeCompiler {
 }
 
 dependencies {
-    implementation(project(":core:common"))
+    api(project(":core:common"))
     implementation(project(":core:ui:common"))
     implementation(project(":core:ui:design"))
     implementation(project(":domain"))

--- a/presentation/src/main/java/kr/co/presentation/feature/account/screen/deletion/AccountDeletionViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/account/screen/deletion/AccountDeletionViewModel.kt
@@ -1,12 +1,11 @@
 package kr.co.presentation.feature.account.screen.deletion
 
-import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
+import kr.co.core.common.logging.AppLogger
 import kr.co.core.ui.common.load.load
 import kr.co.core.ui.common.text.UiText
 import kr.co.domain.feature.account.usecase.DeleteAccountUseCase
@@ -42,6 +41,7 @@ sealed interface AccountDeletionAction {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class AccountDeletionViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val deleteAccount: DeleteAccountUseCase,
 ) : ViewModel(), ContainerHost<AccountDeletionScreenState, AccountDeletionSideEffect> {
@@ -100,7 +100,7 @@ class AccountDeletionViewModel @Inject constructor(
             DomainError.Auth.TooManyRequests -> R.string.too_many_requests
             DomainError.Auth.RequiresRecentLogin -> R.string.requires_recent_sign_in
             else -> {
-                Log.e(TAG, "Failed to delete account: $error")
+                logger.e("Failed to delete account: %s", error)
                 R.string.unexpected_error
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/feature/account/screen/signin/SignInViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/account/screen/signin/SignInViewModel.kt
@@ -1,12 +1,11 @@
 package kr.co.presentation.feature.account.screen.signin
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.ui.common.load.load
 import kr.co.core.ui.common.text.UiText
 import kr.co.domain.feature.account.usecase.SignInUseCase
@@ -45,6 +44,7 @@ sealed interface SignInAction {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class SignInViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val signIn: SignInUseCase,
 ) : ViewModel(), ContainerHost<SignInScreenState, SignInSideEffect> {
@@ -84,7 +84,7 @@ class SignInViewModel @Inject constructor(
             DomainError.Auth.UserNotFound -> R.string.user_not_found
             DomainError.Auth.TooManyRequests -> R.string.too_many_requests
             else -> {
-                Log.e(TAG, "Failed to sign in: $error")
+                logger.e("Failed to sign in: %s", error)
                 R.string.unexpected_error
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/feature/account/screen/signup/SignUpViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/account/screen/signup/SignUpViewModel.kt
@@ -1,11 +1,10 @@
 package kr.co.presentation.feature.account.screen.signup
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.common.extension.toLocalDate
 import kr.co.core.common.model.Gender
 import kr.co.core.ui.common.load.load
@@ -69,6 +68,7 @@ sealed interface SignUpAction {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val createAccount: CreateAccountUseCase,
     private val checkEmailAvailabilityUseCase: CheckEmailAvailabilityUseCase,
@@ -146,11 +146,11 @@ class SignUpViewModel @Inject constructor(
             DomainError.Auth.WeakPassword -> R.string.weak_password
             DomainError.Auth.TooManyRequests -> R.string.too_many_requests
             DomainError.Store.PermissionDenied -> {
-                Log.e(TAG, "Failed to signup: Permission denied")
+                logger.e("Failed to signup: Permission denied")
                 R.string.unexpected_error
             }
             else -> {
-                Log.e(TAG, "Failed to signup: $error")
+                logger.e("Failed to signup: %s", error)
                 R.string.unexpected_error
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/feature/dashboard/screen/dashboard/DashboardViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/dashboard/screen/dashboard/DashboardViewModel.kt
@@ -1,13 +1,12 @@
 package kr.co.presentation.feature.dashboard.screen.dashboard
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.ui.common.load.LoadState
 import kr.co.core.ui.common.load.load
 import kr.co.core.ui.common.text.UiText
@@ -37,6 +36,7 @@ sealed interface DashboardAction
 
 @HiltViewModel
 class DashboardViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val getDashboardUseCase: GetDashboardUseCase,
 ) : ViewModel(), ContainerHost<DashboardScreenState, DashboardSideEffect> {
@@ -76,7 +76,7 @@ class DashboardViewModel @Inject constructor(
     fun handleAction(action: DashboardAction) {}
 
     private fun handleDashboardError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to get dashboard: $error")
+        logger.e("Failed to get dashboard: %s", error)
         postSideEffect(DashboardSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/screen/detail/DiaryDetailViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/screen/detail/DiaryDetailViewModel.kt
@@ -1,13 +1,12 @@
 package kr.co.presentation.feature.diary.screen.detail
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.ui.common.load.LoadState
 import kr.co.core.ui.common.load.data
 import kr.co.core.ui.common.load.load
@@ -51,6 +50,7 @@ sealed interface DiaryDetailAction {
 
 @HiltViewModel
 class DiaryDetailViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val getDiaryStream: GetDiaryStreamUseCase,
     private val deleteDiary: DeleteDiaryUseCase,
@@ -110,7 +110,7 @@ class DiaryDetailViewModel @Inject constructor(
     }
 
     private fun handleDeleteDiaryError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to delete diary: $error")
+        logger.e("Failed to delete diary: %s", error)
         postSideEffect(DiaryDetailSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
     }
 }

--- a/presentation/src/main/java/kr/co/presentation/feature/diary/screen/edit/DiaryEditViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/diary/screen/edit/DiaryEditViewModel.kt
@@ -1,13 +1,12 @@
 package kr.co.presentation.feature.diary.screen.edit
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.ui.common.load.LoadState
 import kr.co.core.ui.common.load.data
 import kr.co.core.ui.common.load.load
@@ -57,6 +56,7 @@ sealed interface DiaryEditAction {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class DiaryEditViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val getDiary: GetDiaryUseCase,
     private val createDiary: CreateDiaryUseCase,
@@ -158,13 +158,13 @@ class DiaryEditViewModel @Inject constructor(
     }
 
     private fun handleGetDiaryError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to get diary: $error")
+        logger.e("Failed to get diary: %s", error)
         postSideEffect(DiaryEditSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
         postSideEffect(DiaryEditSideEffect.LoadFailed)
     }
 
     private fun handleSaveDiaryError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to save diary: $error")
+        logger.e("Failed to save diary: %s", error)
         postSideEffect(DiaryEditSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
     }
 

--- a/presentation/src/main/java/kr/co/presentation/feature/setting/screen/profileedit/ProfileEditViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/setting/screen/profileedit/ProfileEditViewModel.kt
@@ -1,7 +1,7 @@
 package kr.co.presentation.feature.setting.screen.profileedit
 
+import kr.co.core.common.logging.AppLogger
 import android.net.Uri
-import android.util.Log
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -10,7 +10,6 @@ import com.github.michaelbull.result.onErr
 import com.github.michaelbull.result.onOk
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.common.model.Gender
 import kr.co.core.ui.common.load.load
 import kr.co.core.ui.common.text.UiText
@@ -64,6 +63,7 @@ sealed interface ProfileEditAction {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class ProfileEditViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val savedStateHandle: SavedStateHandle,
     private val getUserProfile: GetUserProfileUseCase,
     private val updateUserProfilePhoto: UpdateUserProfilePhotoUseCase,
@@ -122,7 +122,7 @@ class ProfileEditViewModel @Inject constructor(
             DomainError.Auth.WeakPassword -> R.string.weak_password
             DomainError.Auth.TooManyRequests -> R.string.too_many_requests
             else -> {
-                Log.e(TAG, "Failed to update user profile image: $error")
+                logger.e("Failed to update user profile image: %s", error)
                 R.string.unexpected_error
             }
         }
@@ -138,7 +138,7 @@ class ProfileEditViewModel @Inject constructor(
             DomainError.Auth.WeakPassword -> R.string.weak_password
             DomainError.Auth.TooManyRequests -> R.string.too_many_requests
             else -> {
-                Log.e(TAG, "Failed to save user profile: $error")
+                logger.e("Failed to save user profile: %s", error)
                 R.string.unexpected_error
             }
         }

--- a/presentation/src/main/java/kr/co/presentation/feature/setting/screen/settings/SettingsViewModel.kt
+++ b/presentation/src/main/java/kr/co/presentation/feature/setting/screen/settings/SettingsViewModel.kt
@@ -1,13 +1,12 @@
 package kr.co.presentation.feature.setting.screen.settings
 
-import android.util.Log
+import kr.co.core.common.logging.AppLogger
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import com.github.michaelbull.result.get
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.combine
 import kr.co.core.common.error.DomainError
-import kr.co.core.common.extension.TAG
 import kr.co.core.common.model.AppTheme
 import kr.co.core.ui.common.load.load
 import kr.co.core.ui.common.text.UiText
@@ -53,6 +52,7 @@ sealed interface SettingsAction {
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
+    private val logger: AppLogger,
     private val signOut: SignOutUseCase,
     private val getUserProfileStream: GetUserProfileStreamUseCase,
     private val getUserSettingsStream: GetUserSettingsStreamUseCase,
@@ -102,7 +102,7 @@ class SettingsViewModel @Inject constructor(
             DomainError.NetworkUnavailable,
             DomainError.Timeout -> Unit
             else -> {
-                Log.e(TAG, "Failed to prepare sign out dialog: $error")
+                logger.e("Failed to prepare sign out dialog: %s", error)
                 postSideEffect(SettingsSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
             }
         }
@@ -113,19 +113,19 @@ class SettingsViewModel @Inject constructor(
             DomainError.NetworkUnavailable,
             DomainError.Timeout -> Unit
             else -> {
-                Log.e(TAG, "Failed to sign out: $error")
+                logger.e("Failed to sign out: %s", error)
                 postSideEffect(SettingsSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
             }
         }
     }
 
     private fun handleThemeError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to set up theme: $error")
+        logger.e("Failed to set up theme: %s", error)
         postSideEffect(SettingsSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
     }
 
     private fun handleDiarySyncEnabledError(error: DomainError) = intent {
-        Log.e(TAG, "Failed to set up diary synchronization: $error")
+        logger.e("Failed to set up diary synchronization: %s", error)
         postSideEffect(SettingsSideEffect.ShowMessage(UiText.StringResource(R.string.unexpected_error)))
     }
 


### PR DESCRIPTION
## related issue
- closes: #70 

## why
- 릴리즈 빌드의 로그를 숨겨 보안을 강화하고, 간편하게 사용하기 위해 개선합니다.

## what
- Timber 라이브러리 사용
- Debug 모드에서만 로그가 찍히도록 구현
- 이전 Log 사용시 사용했던 TAG 코드 삭제

## impact
- 프로젝트 전체