### PR TITLE
test: domain 모듈 Unit Test Code 추가

### DIFF
--- a/domain/TESTING.md
+++ b/domain/TESTING.md
@@ -1,0 +1,268 @@
+# Domain Testing Guide
+
+> `:domain` 테스트는 Offline-first/LWW 정책, `AppResult<DomainError>` 실패 계약, Flow 상태 전이, sync orchestration을 JVM unit test로 고정한다.
+
+## Scope
+
+- 테스트 러너는 JUnit5(Jupiter)를 사용한다.
+- coroutine/Flow 테스트는 `kotlinx-coroutines-test`의 `runTest`, `StandardTestDispatcher`를 사용한다.
+- 복잡한 호출 순서와 side-effect 검증은 MockK를 사용한다.
+- repository/state repository처럼 데이터 소스 역할을 하는 계약은 Fake 구현을 기본으로 사용한다.
+- Android, Firebase, Room, DataStore, WorkManager 구현체는 `:domain` 테스트에 직접 등장하지 않는다.
+
+## Test Units
+
+현재 production `UseCase`는 모두 최소 1개 이상의 테스트 파일에서 다룬다. 단일 책임 UseCase는 `SomeUseCaseTest` 파일을 두고, stop/all-stop처럼 같은 scheduler 계약을 공유하는 얇은 UseCase는 `Stop...UseCasesTest` 그룹 파일에 묶을 수 있다.
+
+Repository/service/sync 계약 인터페이스 자체는 단독 테스트하지 않는다. 해당 계약은 UseCase 테스트에서 Fake 또는 MockK 구현으로 입력 전달, 상태 전이, 호출 순서, 실패 전파를 검증한다.
+
+### 순수 계산
+
+- `CalendarGenerator`
+  - 월 grid가 항상 42칸인지 검증한다.
+  - 현재월/이전월/다음월 `isCurrentMonth` flag를 검증한다.
+  - 일요일 시작 월, 윤년 2월, 연도/월 목록의 ascending/descending/size를 검증한다.
+
+### 정책/변환 UseCase
+
+- `CreateDiaryUseCase`, `UpdateDiaryUseCase`, `DeleteDiaryUseCase`
+  - `ServerTimeProvider.now()`가 `createdAt`/`updatedAt`에 반영되는지 검증한다.
+  - `DiarySyncStatus.PENDING_CREATE`, `PENDING_UPDATE`, `PENDING_DELETE`가 강제되는지 검증한다.
+  - repository `Err(DomainError...)`가 그대로 전파되는지 검증한다.
+- `UpdateUserProfileUseCase`, `UpdateUserProfilePhotoUseCase`, `UpdateAppThemeUseCase`, `UpdateDiarySyncEnabledUseCase`
+  - current uid와 서버 시간이 repository 입력에 반영되는지 검증한다.
+  - session 실패 시 update repository가 호출되지 않는지 검증한다.
+  - update repository 실패가 그대로 전파되는지 검증한다.
+- `AddRecentSearchUseCase`
+  - blank query는 repository를 호출하지 않는지 검증한다.
+  - query trim 결과와 서버 시간이 repository에 전달되는지 검증한다.
+  - repository 예외는 예외로 전파되는지 검증한다.
+- `GetDiariesByDateRangeStreamUseCase`
+  - center month 기준 `minusMonths(range).atDay(1)`부터 `plusMonths(range).atEndOfMonth()`까지 계산되는지 검증한다.
+
+### Orchestration UseCase
+
+- `SignInUseCase`
+  - sign-in 성공 후 user data sync 성공 시 `Ok(Account)`를 반환한다.
+  - sign-in 실패 시 sync를 호출하지 않는다.
+  - sync 실패 시 `accountService.signOut()` 보상 동작을 호출하고 sync 실패를 반환한다.
+- `SignOutUseCase`
+  - diary full/periodic sync와 realtime sync들을 중지한 뒤 `accountService.signOut()` 결과를 반환한다.
+  - immediate sync는 취소하지 않는 현재 정책을 검증한다.
+- `DeleteAccountUseCase`
+  - 계정 삭제 실패 시 sync stop/storage cleanup을 호출하지 않는다.
+  - 계정 삭제 성공 시 diary/profile/settings sync를 모두 중지하고 반환 uid의 storage를 삭제한다.
+  - storage 삭제 실패는 `Err`로 전파된다.
+- `StartUserDataSyncUseCase`
+  - 마지막 sync가 1시간 이내면 profile/settings sync를 호출하지 않는다.
+  - sync 실행 시 `InProgress.Indeterminate`에서 `Completed`로 상태가 전이되고 timestamp가 저장된다.
+  - profile/settings 각각의 실패가 `Failed(error)` 상태와 `Err(error)`로 전파된다.
+  - profile/settings sync가 같은 invocation 안에서 모두 실행되는지 검증한다.
+- `InitUserStorageUseCase`
+  - 이전 uid가 없으면 삭제 없이 current uid만 저장한다.
+  - 이전 uid가 current uid와 같으면 삭제하지 않는다.
+  - 이전 uid가 다르면 이전 uid storage를 삭제하고 current uid를 저장한다.
+- `InitialDiarySyncUseCase`
+  - 시작 시 `InProgress.Determinate(0f)`를 기록한다.
+  - `performInitialPull` progress callback을 상태로 반영한다.
+  - 성공 시 initial sync completed flag와 `Completed` 상태를 기록한다.
+  - session 실패 또는 pull 실패 시 `Failed(error)` 상태를 기록한다.
+- `StartDiarySyncUseCase`
+  - initial sync 미완료면 `InitialDiarySyncUseCase`를 먼저 호출한다.
+  - initial sync 실패 시 periodic sync를 예약하지 않는다.
+  - initial sync 완료 상태면 full sync와 periodic sync를 예약한다.
+- `RequestMonthSyncUseCase`
+  - current session uid와 target `YearMonth`가 repository로 전달되는지 검증한다.
+  - session/repository 실패가 그대로 전파되는지 검증한다.
+
+### 얇은 위임/Flow UseCase
+
+- `GetDiaryUseCase`, `GetDiaryStreamUseCase`, `GetPagedDiariesUseCase`, `GetDiaryChangeEventUseCase`
+- `GetMonthSyncStatusStreamUseCase`, `GetInitDiarySyncStateStreamUseCase`, `CheckDiarySyncStateUseCase`
+- `GetUserProfileUseCase`, `GetUserProfileStreamUseCase`
+- `GetUserSettingsStreamUseCase`, `GetAppThemeStreamUseCase`, `GetDiarySettingsStreamUseCase`
+- `GetRecentSearchesUseCase`, `RemoveRecentSearchUseCase`, `ClearAllRecentSearchesUseCase`
+- `GetSessionStateStreamUseCase`, `GetCurrentUserUseCase`, `ReloadSessionUseCase`
+- `GetCalendarMonthUseCase`, `GetCalendarYearUseCase`
+- `GetDashboardUseCase`, `GetNetworkStatusStreamUseCase`
+- `CheckEmailAvailabilityUseCase`, `CreateAccountUseCase`, `DeleteUserStorageUseCase`
+- `SyncServerTimeUseCase`, `CheckServiceStatusUseCase`
+- realtime/scheduler start-stop UseCase들
+
+얇은 UseCase도 public contract이므로 최소 1개 이상의 pass-through 테스트를 둔다. Flow UseCase는 upstream Flow와 동일한 값을 방출하는지, `distinctUntilChanged()`가 있는 경우 중복 emission을 제거하는지 검증한다.
+
+## Mocking Strategy
+
+### Fake를 우선 사용할 대상
+
+데이터 상태를 갖거나 Flow를 제공하는 계약은 Fake로 테스트한다.
+
+- `FakeDiaryRepository`
+- `FakeSessionRepository`
+- `FakeUserSettingsRepository`
+- `FakeUserProfileRepository`
+- `FakeSearchRepository`
+- `FakeDiarySyncStateRepository`
+- `FakeUserDataSyncStateRepository`
+- `FakeUserStorageRepository`
+- `FakeServerTimeProvider`
+
+Fake는 구현 세부사항을 재현하지 않는다. 테스트가 검증할 입력을 캡처하고, `AppResult`/Flow/state를 테스트가 원하는 값으로 제어하는 용도로만 둔다.
+
+### MockK를 사용할 대상
+
+명령형 side-effect, 호출 순서, 보상 동작이 중요한 계약은 MockK를 사용한다.
+
+- `AccountService`
+- sync manager/scheduler/realtime scheduler 계약
+- `RemoteConfigRepository`
+- `ServerTimeSyncScheduler`
+- nested UseCase 의존성
+
+호출 순서가 정책인 경우 `coVerifySequence` 또는 `verifySequence`를 사용한다. 순서가 정책이 아니면 `coVerify`/`verify`로 필요한 호출만 검증한다.
+
+## Base Test Class
+
+공용 coroutine 환경은 `kr.co.domain.testing.DomainCoroutineTest`를 상속한다.
+
+```kotlin
+class SomeUseCaseTest : DomainCoroutineTest() {
+    @Test
+    fun `test name`() {
+        runDomainTest {
+            // arrange
+            // act
+            // assert
+        }
+    }
+}
+```
+
+- `runDomainTest` 안에서 suspend UseCase와 Flow를 검증한다.
+- `Dispatchers.Main`은 `StandardTestDispatcher`로 교체된다.
+- 각 테스트 후 `Dispatchers.resetMain()`과 `clearAllMocks()`가 실행된다.
+- 시간 의존성은 `FakeServerTimeProvider`로 고정하고, 기기 시간을 기대값으로 사용하지 않는다.
+
+## Assertions And Fixtures
+
+- `DomainResultAssertions.kt`
+  - `result.assertOk()`
+  - `result.assertOk(expected)`
+  - `result.assertErr()`
+  - `result.assertErr(expected)`
+- `DomainFixtures.kt`
+  - `uid-test`, `uid-other`, `email-test` 같은 비식별 fixture만 사용한다.
+  - 실제 이메일 주소, credential, 일기 본문, 사용자 입력 원문을 테스트 이름이나 문서 예시에 남기지 않는다.
+  - 일기 본문이 필요하지 않으면 `content = ""`를 기본값으로 둔다.
+
+## Flow Testing
+
+- 단일 emission 검증은 `first()`를 사용한다.
+- 여러 emission 검증은 `take(n).toList()`를 사용한다.
+- 테스트 double은 `MutableStateFlow` 또는 `MutableSharedFlow`를 사용한다.
+- `distinctUntilChanged()`가 있는 UseCase는 같은 값을 연속 emit한 뒤 결과 emission 수를 검증한다.
+- Flow collection이 끝나지 않는 구조라면 `take(n)`으로 종료 조건을 명시한다.
+
+## Required Scenarios By Feature
+
+### Account
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `SignInUseCase` | 로그인 성공+sync 성공, 로그인 실패 short-circuit, sync 실패 시 `signOut()` 보상 |
+| `CreateAccountUseCase` | `joinedAt` 서버시간 주입, account service 실패 전파 |
+| `SignOutUseCase` | full/periodic/realtime 중지 후 signOut, signOut 실패 전파 |
+| `DeleteAccountUseCase` | delete 실패 시 cleanup 미호출, 성공 시 전체 sync 중지와 storage 삭제, storage 실패 전파 |
+| `CheckEmailAvailabilityUseCase` | `Ok(true/false)` pass-through, `Err` pass-through |
+
+### User
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `StartUserDataSyncUseCase` | 1시간 gate short-circuit, 성공 상태 전이와 timestamp 저장, profile 실패, settings 실패 |
+| `InitUserStorageUseCase` | 이전 uid 없음, 이전 uid 같음, 이전 uid 다름 |
+| `DeleteUserStorageUseCase` | uid 전달, `Ok`/`Err` pass-through |
+
+### Diary
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `CreateDiaryUseCase` | created/updated 시간 고정, `PENDING_CREATE`, repository 실패 전파 |
+| `UpdateDiaryUseCase` | updated 시간 고정, `PENDING_UPDATE`, repository 실패 전파 |
+| `DeleteDiaryUseCase` | updated 시간 고정, `PENDING_DELETE`, repository 실패 전파 |
+| `GetDiaryUseCase` | date 전달, null diary, repository 실패 전파 |
+| `GetDiaryStreamUseCase` | date 전달, Flow emission |
+| `GetPagedDiariesUseCase` | query/date/limit/offset 전달, 실패 전파 |
+| `GetDiariesByDateRangeStreamUseCase` | 기본 range=1, custom range, month boundary 계산 |
+| `GetDiaryChangeEventUseCase` | repository event Flow pass-through |
+
+### Diary Sync
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `InitialDiarySyncUseCase` | 0f 시작, progress 반영, 완료 flag, session 실패, pull 실패 |
+| `StartDiarySyncUseCase` | initial 미완료 성공, initial 실패, initial 완료 후 full+periodic 예약 |
+| `RequestMonthSyncUseCase` | session uid 전달, session 실패, repository 실패 |
+| `CheckDiarySyncStateUseCase` | pending 0이면 false, pending 양수면 true |
+| `StartRealtimeDiarySyncUseCase` | start 호출 후 `Ok(Unit)`, start 예외 전파 |
+| `StopRealtimeDiarySyncUseCase` | stop 호출 |
+| `StopAllDiarySyncUseCase` | all sync cancel + realtime stop |
+| `StopDiaryFullSyncUseCase` | full sync cancel |
+| `StopDiaryPeriodicSyncUseCase` | periodic sync cancel |
+| `GetInitDiarySyncStateStreamUseCase` | state Flow pass-through |
+| `GetMonthSyncStatusStreamUseCase` | yearMonth 전달과 status Flow pass-through |
+
+### Profile And Settings
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `UpdateUserProfileUseCase` | uid/server time 주입, session 실패 시 repository 미호출, update 실패 전파 |
+| `UpdateUserProfilePhotoUseCase` | uid/photoUrl/server time 전달, session 실패, update 실패 |
+| `GetUserProfileUseCase` | 첫 emission 반환, 실패 emission 반환 |
+| `GetUserProfileStreamUseCase` | stream pass-through, duplicate 제거 |
+| `UpdateAppThemeUseCase` | uid/theme/server time 전달, session 실패, update 실패 |
+| `GetAppThemeStreamUseCase` | duplicate 제거 |
+| `GetUserSettingsStreamUseCase` | stream pass-through, duplicate 제거 |
+| `UpdateDiarySyncEnabledUseCase` | uid/enabled/server time 전달, session 실패, update 실패 |
+| `GetDiarySettingsStreamUseCase` | enabled Flow pass-through |
+| profile/settings realtime start-stop/all-stop | scheduler 호출과 예외 전파 |
+
+### Search
+
+| UseCase | 필수 케이스 |
+| --- | --- |
+| `AddRecentSearchUseCase` | blank 무시, trim+server time 전달, repository 예외 전파 |
+| `GetRecentSearchesUseCase` | Flow pass-through |
+| `RemoveRecentSearchUseCase` | query 전달, repository 예외 전파 |
+| `ClearAllRecentSearchesUseCase` | clear 호출, repository 예외 전파 |
+
+### Calendar, Session, Dashboard, Service
+
+| UseCase/Unit | 필수 케이스 |
+| --- | --- |
+| `CalendarGenerator` | 42칸, 현재월 flag, 일요일 시작 월, 윤년 2월, ascending/descending/size |
+| `GetCalendarMonthUseCase` | `YearMonth` 전달 |
+| `GetCalendarYearUseCase` | `Year` 전달 |
+| `GetSessionStateStreamUseCase` | Flow pass-through |
+| `GetCurrentUserUseCase` | current user `Ok`/`Err` pass-through |
+| `ReloadSessionUseCase` | reload `Ok`/`Err` pass-through |
+| `GetDashboardUseCase` | dashboard `Ok`/`Err` pass-through |
+| `GetNetworkStatusStreamUseCase` | online/offline Flow pass-through |
+| `SyncServerTimeUseCase` | sync 성공 시 scheduler 미호출, sync 실패 시 `scheduleSync()` |
+| `CheckServiceStatusUseCase` | fetch 후 active, fetch 후 maintenance reason |
+
+## Verification
+
+테스트 인프라나 domain 테스트를 바꾼 뒤 최소 아래 명령을 실행한다.
+
+```bash
+./gradlew :domain:test
+rg "android\\.|androidx\\.compose|Firebase|Room|WorkManager|DataStore" domain/src/main/java
+rg "Timber|android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" domain/src/main/java -g "*.kt"
+```
+
+계약 변경이 data/presentation에 영향을 주면 아래도 실행한다.
+
+```bash
+./gradlew :data:compileDebugKotlin :presentation:compileDebugKotlin
+```

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -14,6 +14,10 @@ kotlin {
     }
 }
 
+tasks.test {
+    useJUnitPlatform()
+}
+
 dependencies {
     implementation(project(":core:common"))
 
@@ -22,4 +26,10 @@ dependencies {
     implementation(libs.androidx.paging.common)
 
     implementation(libs.kotlin.result.coroutines)
+
+    // unit test
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }

--- a/domain/src/main/java/kr/co/domain/feature/account/usecase/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/feature/account/usecase/DeleteAccountUseCase.kt
@@ -23,6 +23,6 @@ class DeleteAccountUseCase @Inject constructor(
         stopAllUserProfileSync()
         stopAllUserSettingsSync()
 
-        deleteUserStorage(uid)
+        deleteUserStorage(uid).bind()
     }
 }

--- a/domain/src/main/java/kr/co/domain/feature/diary/usecase/sync/RequestMonthSyncUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/feature/diary/usecase/sync/RequestMonthSyncUseCase.kt
@@ -13,6 +13,6 @@ class RequestMonthSyncUseCase @Inject constructor(
 ) {
     suspend operator fun invoke(yearMonth: YearMonth): AppResult<Unit> = coroutineBinding {
         val userSession = sessionRepository.getCurrentUser().bind()
-        diaryRepository.requestMonthSync(userSession.uid, yearMonth)
+        diaryRepository.requestMonthSync(userSession.uid, yearMonth).bind()
     }
 }

--- a/domain/src/main/java/kr/co/domain/feature/user/usecase/InitUserStorageUseCase.kt
+++ b/domain/src/main/java/kr/co/domain/feature/user/usecase/InitUserStorageUseCase.kt
@@ -1,6 +1,6 @@
 package kr.co.domain.feature.user.usecase
 
-import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.coroutines.coroutineBinding
 import kr.co.core.common.result.AppResult
 import kr.co.domain.feature.session.repository.SessionRepository
 import javax.inject.Inject
@@ -9,14 +9,13 @@ class InitUserStorageUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val deleteUserStorage: DeleteUserStorageUseCase,
 ) {
-    suspend operator fun invoke(currentUid: String): AppResult<Unit> {
+    suspend operator fun invoke(currentUid: String): AppResult<Unit> = coroutineBinding {
         val lastUid = sessionRepository.getLastSignInUid()
 
         if (lastUid != null && lastUid != currentUid) {
-            deleteUserStorage(lastUid)
+            deleteUserStorage(lastUid).bind()
         }
 
         sessionRepository.setLastSignInUid(currentUid)
-        return Ok(Unit)
     }
 }

--- a/domain/src/test/java/kr/co/domain/feature/account/usecase/CheckEmailAvailabilityUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/account/usecase/CheckEmailAvailabilityUseCaseTest.kt
@@ -1,0 +1,45 @@
+package kr.co.domain.feature.account.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.account.service.AccountService
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Test
+
+class CheckEmailAvailabilityUseCaseTest : DomainCoroutineTest() {
+
+    private val accountService = mockk<AccountService>()
+    private val useCase = CheckEmailAvailabilityUseCase(accountService)
+
+    @Test
+    fun `returns account service result when email is available`() {
+        runDomainTest {
+            coEvery { accountService.checkEmailAvailability(DomainFixtures.EMAIL) } returns Ok(true)
+
+            val result = useCase(DomainFixtures.EMAIL)
+
+            result.assertOk(true)
+            coVerify(exactly = 1) { accountService.checkEmailAvailability(DomainFixtures.EMAIL) }
+        }
+    }
+
+    @Test
+    fun `returns account service failure`() {
+        runDomainTest {
+            val error = DomainError.NetworkUnavailable
+            coEvery { accountService.checkEmailAvailability(DomainFixtures.EMAIL) } returns Err(error)
+
+            val result = useCase(DomainFixtures.EMAIL)
+
+            result.assertErr(error)
+            coVerify(exactly = 1) { accountService.checkEmailAvailability(DomainFixtures.EMAIL) }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/account/usecase/CreateAccountUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/account/usecase/CreateAccountUseCaseTest.kt
@@ -1,0 +1,53 @@
+package kr.co.domain.feature.account.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.account.service.AccountService
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Test
+
+class CreateAccountUseCaseTest : DomainCoroutineTest() {
+
+    private val accountService = mockk<AccountService>()
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+    private val useCase = CreateAccountUseCase(accountService, serverTime)
+
+    @Test
+    fun `creates account with server time as joined at`() {
+        runDomainTest {
+            val signUpInfo = DomainFixtures.signUpInfo()
+            coEvery { accountService.createAccount(signUpInfo, DomainFixtures.FIXED_TIME) } returns Ok(Unit)
+
+            val result = useCase(signUpInfo)
+
+            result.assertOk(Unit)
+            coVerify(exactly = 1) {
+                accountService.createAccount(signUpInfo, DomainFixtures.FIXED_TIME)
+            }
+        }
+    }
+
+    @Test
+    fun `returns account service failure`() {
+        runDomainTest {
+            val error = DomainError.Auth.EmailAlreadyInUse
+            val signUpInfo = DomainFixtures.signUpInfo()
+            coEvery { accountService.createAccount(signUpInfo, DomainFixtures.FIXED_TIME) } returns Err(error)
+
+            val result = useCase(signUpInfo)
+
+            result.assertErr(error)
+            coVerify(exactly = 1) {
+                accountService.createAccount(signUpInfo, DomainFixtures.FIXED_TIME)
+            }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/account/usecase/DeleteAccountUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/account/usecase/DeleteAccountUseCaseTest.kt
@@ -1,0 +1,94 @@
+package kr.co.domain.feature.account.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.account.service.AccountService
+import kr.co.domain.feature.diary.usecase.sync.StopAllDiarySyncUseCase
+import kr.co.domain.feature.profile.usecase.sync.StopAllUserProfileSyncUseCase
+import kr.co.domain.feature.setting.usecase.sync.StopAllUserSettingsSyncUseCase
+import kr.co.domain.feature.user.usecase.DeleteUserStorageUseCase
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeUserStorageRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeleteAccountUseCaseTest : DomainCoroutineTest() {
+
+    private val accountService = mockk<AccountService>()
+    private val stopAllDiarySync = mockk<StopAllDiarySyncUseCase>()
+    private val stopAllUserProfileSync = mockk<StopAllUserProfileSyncUseCase>()
+    private val stopAllUserSettingsSync = mockk<StopAllUserSettingsSyncUseCase>()
+    private val userStorageRepository = FakeUserStorageRepository()
+    private val deleteUserStorage = DeleteUserStorageUseCase(userStorageRepository)
+    private val useCase = DeleteAccountUseCase(
+        accountService = accountService,
+        stopAllDiarySync = stopAllDiarySync,
+        stopAllUserProfileSync = stopAllUserProfileSync,
+        stopAllUserSettingsSync = stopAllUserSettingsSync,
+        deleteUserStorage = deleteUserStorage,
+    )
+
+    @Test
+    fun `does not clean up sync or storage when account deletion fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.RequiresRecentLogin
+            coEvery { accountService.deleteAccount("value-test") } returns Err(error)
+
+            val result = useCase("value-test")
+
+            result.assertErr(error)
+            coVerify(exactly = 1) { accountService.deleteAccount("value-test") }
+            verify(exactly = 0) { stopAllDiarySync() }
+            verify(exactly = 0) { stopAllUserProfileSync() }
+            verify(exactly = 0) { stopAllUserSettingsSync() }
+            assertEquals(emptyList<String>(), userStorageRepository.deletedUids)
+        }
+    }
+
+    @Test
+    fun `stops all sync work and deletes returned user storage when account deletion succeeds`() {
+        runDomainTest {
+            coEvery { accountService.deleteAccount("value-test") } returns Ok(DomainFixtures.UID)
+            every { stopAllDiarySync() } returns Unit
+            every { stopAllUserProfileSync() } returns Unit
+            every { stopAllUserSettingsSync() } returns Unit
+
+            val result = useCase("value-test")
+
+            result.assertOk(Unit)
+            verify(exactly = 1) { stopAllDiarySync() }
+            verify(exactly = 1) { stopAllUserProfileSync() }
+            verify(exactly = 1) { stopAllUserSettingsSync() }
+            assertEquals(listOf(DomainFixtures.UID), userStorageRepository.deletedUids)
+        }
+    }
+
+    @Test
+    fun `returns storage deletion failure after stopping sync work`() {
+        runDomainTest {
+            val error = DomainError.Storage.PermissionDenied
+            userStorageRepository.deleteUserStorageResult = Err(error)
+            coEvery { accountService.deleteAccount("value-test") } returns Ok(DomainFixtures.UID)
+            every { stopAllDiarySync() } returns Unit
+            every { stopAllUserProfileSync() } returns Unit
+            every { stopAllUserSettingsSync() } returns Unit
+
+            val result = useCase("value-test")
+
+            result.assertErr(error)
+            verify(exactly = 1) { stopAllDiarySync() }
+            verify(exactly = 1) { stopAllUserProfileSync() }
+            verify(exactly = 1) { stopAllUserSettingsSync() }
+            assertEquals(listOf(DomainFixtures.UID), userStorageRepository.deletedUids)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/account/usecase/SignInUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/account/usecase/SignInUseCaseTest.kt
@@ -1,0 +1,74 @@
+package kr.co.domain.feature.account.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.account.service.AccountService
+import kr.co.domain.feature.user.usecase.StartUserDataSyncUseCase
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Test
+
+class SignInUseCaseTest : DomainCoroutineTest() {
+
+    private val accountService = mockk<AccountService>()
+    private val startUserDataSync = mockk<StartUserDataSyncUseCase>()
+    private val useCase = SignInUseCase(
+        accountService = accountService,
+        startUserDataSync = startUserDataSync,
+    )
+
+    @Test
+    fun `returns account when sign in and user data sync succeed`() {
+        runDomainTest {
+            val account = DomainFixtures.account()
+            coEvery { accountService.signIn(DomainFixtures.EMAIL, "value-test") } returns Ok(account)
+            coEvery { startUserDataSync(account.uid) } returns Ok(Unit)
+
+            val result = useCase(DomainFixtures.EMAIL, "value-test")
+
+            result.assertOk(account)
+            coVerify(exactly = 1) { accountService.signIn(DomainFixtures.EMAIL, "value-test") }
+            coVerify(exactly = 1) { startUserDataSync(account.uid) }
+            coVerify(exactly = 0) { accountService.signOut() }
+        }
+    }
+
+    @Test
+    fun `does not start user data sync when sign in fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.InvalidCredentials
+            coEvery { accountService.signIn(DomainFixtures.EMAIL, "value-test") } returns Err(error)
+
+            val result = useCase(DomainFixtures.EMAIL, "value-test")
+
+            result.assertErr(error)
+            coVerify(exactly = 1) { accountService.signIn(DomainFixtures.EMAIL, "value-test") }
+            coVerify(exactly = 0) { startUserDataSync(any()) }
+            coVerify(exactly = 0) { accountService.signOut() }
+        }
+    }
+
+    @Test
+    fun `signs out as compensation when user data sync fails`() {
+        runDomainTest {
+            val account = DomainFixtures.account()
+            val error = DomainError.NetworkUnavailable
+            coEvery { accountService.signIn(DomainFixtures.EMAIL, "value-test") } returns Ok(account)
+            coEvery { startUserDataSync(account.uid) } returns Err(error)
+            coEvery { accountService.signOut() } returns Ok(Unit)
+
+            val result = useCase(DomainFixtures.EMAIL, "value-test")
+
+            result.assertErr(error)
+            coVerify(exactly = 1) { accountService.signIn(DomainFixtures.EMAIL, "value-test") }
+            coVerify(exactly = 1) { startUserDataSync(account.uid) }
+            coVerify(exactly = 1) { accountService.signOut() }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/account/usecase/SignOutUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/account/usecase/SignOutUseCaseTest.kt
@@ -1,0 +1,77 @@
+package kr.co.domain.feature.account.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.account.service.AccountService
+import kr.co.domain.feature.diary.sync.DiarySyncScheduler
+import kr.co.domain.feature.diary.usecase.sync.StopRealtimeDiarySyncUseCase
+import kr.co.domain.feature.profile.usecase.sync.StopRealtimeUserProfileSyncUseCase
+import kr.co.domain.feature.setting.usecase.sync.StopRealtimeUserSettingsSyncUseCase
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Test
+
+class SignOutUseCaseTest : DomainCoroutineTest() {
+
+    private val diarySyncScheduler = mockk<DiarySyncScheduler>(relaxed = true)
+    private val stopRealtimeDiarySync = mockk<StopRealtimeDiarySyncUseCase>()
+    private val stopRealtimeUserProfileSync = mockk<StopRealtimeUserProfileSyncUseCase>()
+    private val stopRealtimeUserSettingsSync = mockk<StopRealtimeUserSettingsSyncUseCase>()
+    private val accountService = mockk<AccountService>()
+    private val useCase = SignOutUseCase(
+        diarySyncScheduler = diarySyncScheduler,
+        stopRealtimeDiarySync = stopRealtimeDiarySync,
+        stopRealtimeUserProfileSync = stopRealtimeUserProfileSync,
+        stopRealtimeUserSettingsSync = stopRealtimeUserSettingsSync,
+        accountService = accountService,
+    )
+
+    @Test
+    fun `cancels non immediate sync and realtime sync before signing out`() {
+        runDomainTest {
+            every { stopRealtimeDiarySync() } returns Unit
+            every { stopRealtimeUserProfileSync() } returns Unit
+            every { stopRealtimeUserSettingsSync() } returns Unit
+            coEvery { accountService.signOut() } returns Ok(Unit)
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            verify(exactly = 1) { diarySyncScheduler.cancelFullSync() }
+            verify(exactly = 1) { diarySyncScheduler.cancelPeriodicSync() }
+            verify(exactly = 0) { diarySyncScheduler.cancelImmediateSync() }
+            verify(exactly = 1) { stopRealtimeDiarySync() }
+            verify(exactly = 1) { stopRealtimeUserProfileSync() }
+            verify(exactly = 1) { stopRealtimeUserSettingsSync() }
+            coVerify(exactly = 1) { accountService.signOut() }
+        }
+    }
+
+    @Test
+    fun `returns sign out failure after stopping sync work`() {
+        runDomainTest {
+            val error = DomainError.NetworkUnavailable
+            every { stopRealtimeDiarySync() } returns Unit
+            every { stopRealtimeUserProfileSync() } returns Unit
+            every { stopRealtimeUserSettingsSync() } returns Unit
+            coEvery { accountService.signOut() } returns Err(error)
+
+            val result = useCase()
+
+            result.assertErr(error)
+            verify(exactly = 1) { diarySyncScheduler.cancelFullSync() }
+            verify(exactly = 1) { diarySyncScheduler.cancelPeriodicSync() }
+            verify(exactly = 1) { stopRealtimeDiarySync() }
+            verify(exactly = 1) { stopRealtimeUserProfileSync() }
+            verify(exactly = 1) { stopRealtimeUserSettingsSync() }
+            coVerify(exactly = 1) { accountService.signOut() }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/calendar/generator/CalendarGeneratorTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/calendar/generator/CalendarGeneratorTest.kt
@@ -1,0 +1,93 @@
+package kr.co.domain.feature.calendar.generator
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.Year
+import java.time.YearMonth
+
+class CalendarGeneratorTest {
+
+    private val generator = CalendarGenerator()
+
+    @Test
+    fun `generates forty two days and marks current month days`() {
+        val month = generator.generateMonth(YearMonth.of(2026, 1))
+
+        assertEquals(CalendarGenerator.CALENDAR_GRID_DAY_COUNT, month.days.size)
+        assertEquals(31, month.days.count { it.isCurrentMonth })
+        assertEquals(LocalDate.of(2026, 1, 1), month.days.first { it.isCurrentMonth }.date)
+        assertEquals(LocalDate.of(2026, 1, 31), month.days.last { it.isCurrentMonth }.date)
+        assertFalse(month.days.first().isCurrentMonth)
+    }
+
+    @Test
+    fun `starts with current month when first day is sunday`() {
+        val month = generator.generateMonth(YearMonth.of(2023, 10))
+
+        assertEquals(LocalDate.of(2023, 10, 1), month.days.first().date)
+        assertTrue(month.days.first().isCurrentMonth)
+        assertEquals(CalendarGenerator.CALENDAR_GRID_DAY_COUNT, month.days.size)
+    }
+
+    @Test
+    fun `generates leap year february with twenty nine current days`() {
+        val month = generator.generateMonth(YearMonth.of(2024, 2))
+
+        assertEquals(29, month.days.count { it.isCurrentMonth })
+        assertTrue(month.days.any { it.date == LocalDate.of(2024, 2, 29) && it.isCurrentMonth })
+    }
+
+    @Test
+    fun `generates full year months in ascending order`() {
+        val months = generator.generateMonths(Year.of(2026), CalendarGenerator.SortOrder.Ascending)
+
+        assertEquals(CalendarGenerator.MONTHS_IN_YEAR, months.size)
+        assertEquals(YearMonth.of(2026, 1), months.first().yearMonth)
+        assertEquals(YearMonth.of(2026, 12), months.last().yearMonth)
+    }
+
+    @Test
+    fun `generates full year months in descending order`() {
+        val months = generator.generateMonths(Year.of(2026), CalendarGenerator.SortOrder.Descending)
+
+        assertEquals(CalendarGenerator.MONTHS_IN_YEAR, months.size)
+        assertEquals(YearMonth.of(2026, 12), months.first().yearMonth)
+        assertEquals(YearMonth.of(2026, 1), months.last().yearMonth)
+    }
+
+    @Test
+    fun `generates relative month window in requested size and order`() {
+        val target = YearMonth.of(2026, 6)
+
+        val ascending = generator.generateMonths(
+            yearMonth = target,
+            size = 3,
+            sortOrder = CalendarGenerator.SortOrder.Ascending,
+        )
+        val descending = generator.generateMonths(
+            yearMonth = target,
+            size = 3,
+            sortOrder = CalendarGenerator.SortOrder.Descending,
+        )
+
+        assertEquals(
+            listOf(
+                YearMonth.of(2026, 4),
+                YearMonth.of(2026, 5),
+                YearMonth.of(2026, 6),
+            ),
+            ascending.map { it.yearMonth },
+        )
+        assertEquals(
+            listOf(
+                YearMonth.of(2026, 6),
+                YearMonth.of(2026, 5),
+                YearMonth.of(2026, 4),
+            ),
+            descending.map { it.yearMonth },
+        )
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/calendar/usecase/GetCalendarMonthUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/calendar/usecase/GetCalendarMonthUseCaseTest.kt
@@ -1,0 +1,22 @@
+package kr.co.domain.feature.calendar.usecase
+
+import kr.co.domain.testing.fake.FakeCalendarRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class GetCalendarMonthUseCaseTest {
+
+    @Test
+    fun `returns monthly pages flow and passes target year month`() {
+        val repository = FakeCalendarRepository()
+        val useCase = GetCalendarMonthUseCase(repository)
+        val target = YearMonth.of(2026, 6)
+
+        val result = useCase(target)
+
+        assertSame(repository.monthlyPagesFlow, result)
+        assertEquals(listOf(target), repository.requestedYearMonths)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/calendar/usecase/GetCalendarYearUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/calendar/usecase/GetCalendarYearUseCaseTest.kt
@@ -1,0 +1,22 @@
+package kr.co.domain.feature.calendar.usecase
+
+import kr.co.domain.testing.fake.FakeCalendarRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.time.Year
+
+class GetCalendarYearUseCaseTest {
+
+    @Test
+    fun `returns yearly pages flow and passes target year`() {
+        val repository = FakeCalendarRepository()
+        val useCase = GetCalendarYearUseCase(repository)
+        val target = Year.of(2026)
+
+        val result = useCase(target)
+
+        assertSame(repository.yearlyPagesFlow, result)
+        assertEquals(listOf(target), repository.requestedYears)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/dashboard/usecase/GetDashboardUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/dashboard/usecase/GetDashboardUseCaseTest.kt
@@ -1,0 +1,43 @@
+package kr.co.domain.feature.dashboard.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.dashboard.model.Dashboard
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDashboardRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetDashboardUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns dashboard from repository`() {
+        runDomainTest {
+            val dashboard = Dashboard(totalDiaryCount = 3)
+            val repository = FakeDashboardRepository(dashboardResult = Ok(dashboard))
+            val useCase = GetDashboardUseCase(repository)
+
+            val result = useCase()
+
+            result.assertOk(dashboard)
+            assertEquals(1, repository.getDashboardCallCount)
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Store.NotFound
+            val repository = FakeDashboardRepository(dashboardResult = Err(error))
+            val useCase = GetDashboardUseCase(repository)
+
+            val result = useCase()
+
+            result.assertErr(error)
+            assertEquals(1, repository.getDashboardCallCount)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/CreateDiaryUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/CreateDiaryUseCaseTest.kt
@@ -1,0 +1,60 @@
+package kr.co.domain.feature.diary.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.state.DiarySyncStatus
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CreateDiaryUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `creates diary with server timestamps and pending create status`() {
+        runDomainTest {
+            val diaryRepository = FakeDiaryRepository()
+            val useCase = CreateDiaryUseCase(diaryRepository, serverTime)
+            val input = DomainFixtures.diary(
+                createdAt = 1L,
+                updatedAt = 2L,
+                syncStatus = DiarySyncStatus.SYNCED,
+            )
+
+            val result = useCase(input)
+
+            result.assertOk(Unit)
+            assertEquals(1, diaryRepository.createdDiaries.size)
+            assertEquals(
+                input.copy(
+                    createdAt = DomainFixtures.FIXED_TIME,
+                    updatedAt = DomainFixtures.FIXED_TIME,
+                    syncStatus = DiarySyncStatus.PENDING_CREATE,
+                ),
+                diaryRepository.createdDiaries.single(),
+            )
+        }
+    }
+
+    @Test
+    fun `returns repository failure when create diary fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val diaryRepository = FakeDiaryRepository().apply {
+                createDiaryResult = Err(error)
+            }
+            val useCase = CreateDiaryUseCase(diaryRepository, serverTime)
+
+            val result = useCase(DomainFixtures.diary())
+
+            result.assertErr(error)
+            assertEquals(1, diaryRepository.createdDiaries.size)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/DeleteDiaryUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/DeleteDiaryUseCaseTest.kt
@@ -1,0 +1,56 @@
+package kr.co.domain.feature.diary.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.state.DiarySyncStatus
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeleteDiaryUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `deletes diary with server updatedAt and pending delete status`() {
+        runDomainTest {
+            val diaryRepository = FakeDiaryRepository()
+            val useCase = DeleteDiaryUseCase(diaryRepository, serverTime)
+            val input = DomainFixtures.diary(
+                createdAt = 1L,
+                updatedAt = 2L,
+                syncStatus = DiarySyncStatus.SYNCED,
+            )
+            val expected = input.copy(
+                updatedAt = DomainFixtures.FIXED_TIME,
+                syncStatus = DiarySyncStatus.PENDING_DELETE,
+            )
+
+            val result = useCase(input)
+
+            result.assertOk(Unit)
+            assertEquals(listOf(expected), diaryRepository.deletedDiaries)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when delete diary fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val diaryRepository = FakeDiaryRepository().apply {
+                deleteDiaryResult = Err(error)
+            }
+            val useCase = DeleteDiaryUseCase(diaryRepository, serverTime)
+
+            val result = useCase(DomainFixtures.diary())
+
+            result.assertErr(error)
+            assertEquals(1, diaryRepository.deletedDiaries.size)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiariesByDateRangeStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiariesByDateRangeStreamUseCaseTest.kt
@@ -1,0 +1,50 @@
+package kr.co.domain.feature.diary.usecase
+
+import kotlinx.coroutines.flow.first
+import kr.co.domain.feature.diary.model.Diary
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+class GetDiariesByDateRangeStreamUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `uses previous current and next month as default date range`() {
+        runDomainTest {
+            val diary = DomainFixtures.diary(date = LocalDate.of(2026, 2, 14))
+            val diaryRepository = FakeDiaryRepository(initialDiaries = listOf(diary))
+            val useCase = GetDiariesByDateRangeStreamUseCase(diaryRepository)
+
+            val result = useCase(YearMonth.of(2026, 2)).first()
+
+            assertEquals(listOf(diary), result)
+            assertEquals(
+                listOf(LocalDate.of(2026, 1, 1) to LocalDate.of(2026, 3, 31)),
+                diaryRepository.requestedDateRanges,
+            )
+        }
+    }
+
+    @Test
+    fun `uses custom month range around center month`() {
+        runDomainTest {
+            val diaryRepository = FakeDiaryRepository()
+            val useCase = GetDiariesByDateRangeStreamUseCase(diaryRepository)
+
+            val result = useCase(
+                centerMonth = YearMonth.of(2026, 2),
+                monthRange = 2L,
+            ).first()
+
+            assertEquals(emptyList<Diary>(), result)
+            assertEquals(
+                listOf(LocalDate.of(2025, 12, 1) to LocalDate.of(2026, 4, 30)),
+                diaryRepository.requestedDateRanges,
+            )
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryChangeEventUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryChangeEventUseCaseTest.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.feature.diary.usecase
+
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetDiaryChangeEventUseCaseTest {
+
+    @Test
+    fun `returns diary change event flow`() {
+        val repository = FakeDiaryRepository()
+        val useCase = GetDiaryChangeEventUseCase(repository)
+
+        val result = useCase()
+
+        assertSame(repository.diaryChangeEvent, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryStreamUseCaseTest.kt
@@ -1,0 +1,20 @@
+package kr.co.domain.feature.diary.usecase
+
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetDiaryStreamUseCaseTest {
+
+    @Test
+    fun `returns diary stream for requested date`() {
+        val repository = FakeDiaryRepository(listOf(DomainFixtures.diary()))
+        val useCase = GetDiaryStreamUseCase(repository)
+        val expected = repository.getDiaryStream(DomainFixtures.DATE)
+
+        val result = useCase(DomainFixtures.DATE)
+
+        assertSame(expected, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetDiaryUseCaseTest.kt
@@ -1,0 +1,44 @@
+package kr.co.domain.feature.diary.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Test
+
+class GetDiaryUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns diary from repository`() {
+        runDomainTest {
+            val diary = DomainFixtures.diary()
+            val repository = FakeDiaryRepository().apply {
+                getDiaryResult = Ok(diary)
+            }
+            val useCase = GetDiaryUseCase(repository)
+
+            val result = useCase(DomainFixtures.DATE)
+
+            result.assertOk(diary)
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Store.NotFound
+            val repository = FakeDiaryRepository().apply {
+                getDiaryResult = Err(error)
+            }
+            val useCase = GetDiaryUseCase(repository)
+
+            val result = useCase(DomainFixtures.DATE)
+
+            result.assertErr(error)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetPagedDiariesUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/GetPagedDiariesUseCaseTest.kt
@@ -1,0 +1,67 @@
+package kr.co.domain.feature.diary.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import kr.co.domain.testing.fake.PagedDiariesRequest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class GetPagedDiariesUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `passes paging filters to repository and returns diaries`() {
+        runDomainTest {
+            val diaries = listOf(DomainFixtures.diary())
+            val repository = FakeDiaryRepository().apply {
+                getPagedDiariesResult = Ok(diaries)
+            }
+            val useCase = GetPagedDiariesUseCase(repository)
+            val startDate = LocalDate.of(2026, 1, 1)
+            val endDate = LocalDate.of(2026, 1, 31)
+
+            val result = useCase(
+                query = "query-test",
+                startDate = startDate,
+                endDate = endDate,
+                limit = 20,
+                offset = 40,
+            )
+
+            result.assertOk(diaries)
+            assertEquals(
+                listOf(
+                    PagedDiariesRequest(
+                        query = "query-test",
+                        startDate = startDate,
+                        endDate = endDate,
+                        limit = 20,
+                        offset = 40,
+                    )
+                ),
+                repository.pagedDiaryRequests,
+            )
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Store.NotFound
+            val repository = FakeDiaryRepository().apply {
+                getPagedDiariesResult = Err(error)
+            }
+            val useCase = GetPagedDiariesUseCase(repository)
+
+            val result = useCase(limit = 10, offset = 0)
+
+            result.assertErr(error)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/UpdateDiaryUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/UpdateDiaryUseCaseTest.kt
@@ -1,0 +1,56 @@
+package kr.co.domain.feature.diary.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.state.DiarySyncStatus
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateDiaryUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `updates diary with server updatedAt and pending update status`() {
+        runDomainTest {
+            val diaryRepository = FakeDiaryRepository()
+            val useCase = UpdateDiaryUseCase(diaryRepository, serverTime)
+            val input = DomainFixtures.diary(
+                createdAt = 1L,
+                updatedAt = 2L,
+                syncStatus = DiarySyncStatus.SYNCED,
+            )
+            val expected = input.copy(
+                updatedAt = DomainFixtures.FIXED_TIME,
+                syncStatus = DiarySyncStatus.PENDING_UPDATE,
+            )
+
+            val result = useCase(input)
+
+            result.assertOk(expected)
+            assertEquals(listOf(expected), diaryRepository.updatedDiaries)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when update diary fails`() {
+        runDomainTest {
+            val error = DomainError.Diary.NotFound
+            val diaryRepository = FakeDiaryRepository().apply {
+                updateDiaryResult = Err(error)
+            }
+            val useCase = UpdateDiaryUseCase(diaryRepository, serverTime)
+
+            val result = useCase(DomainFixtures.diary())
+
+            result.assertErr(error)
+            assertEquals(1, diaryRepository.updatedDiaries.size)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/setting/GetDiarySettingsStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/setting/GetDiarySettingsStreamUseCaseTest.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.feature.diary.usecase.setting
+
+import kr.co.domain.testing.fake.FakeUserSettingsRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetDiarySettingsStreamUseCaseTest {
+
+    @Test
+    fun `returns diary sync enabled stream`() {
+        val repository = FakeUserSettingsRepository(initialDiarySyncEnabled = true)
+        val useCase = GetDiarySettingsStreamUseCase(repository)
+
+        val result = useCase()
+
+        assertSame(repository.diarySyncEnabledStream, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/setting/UpdateDiarySyncEnabledUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/setting/UpdateDiarySyncEnabledUseCaseTest.kt
@@ -1,0 +1,83 @@
+package kr.co.domain.feature.diary.usecase.setting
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.DiarySyncEnabledUpdate
+import kr.co.domain.testing.fake.FakeSessionRepository
+import kr.co.domain.testing.fake.FakeUserSettingsRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateDiarySyncEnabledUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `updates diary sync enabled with current user uid and server time`() {
+        runDomainTest {
+            val settingsRepository = FakeUserSettingsRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(enabled = true)
+
+            result.assertOk(Unit)
+            assertEquals(
+                listOf(
+                    DiarySyncEnabledUpdate(
+                        uid = DomainFixtures.UID,
+                        enabled = true,
+                        lastModifiedAt = DomainFixtures.FIXED_TIME,
+                    )
+                ),
+                settingsRepository.diarySyncEnabledUpdates,
+            )
+        }
+    }
+
+    @Test
+    fun `does not update diary sync setting when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val settingsRepository = FakeUserSettingsRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(enabled = false)
+
+            result.assertErr(error)
+            assertEquals(emptyList<DiarySyncEnabledUpdate>(), settingsRepository.diarySyncEnabledUpdates)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when diary sync setting update fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val settingsRepository = FakeUserSettingsRepository().apply {
+                updateDiarySyncEnabledResult = Err(error)
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(enabled = true)
+
+            result.assertErr(error)
+            assertEquals(1, settingsRepository.diarySyncEnabledUpdates.size)
+        }
+    }
+
+    private fun createUseCase(
+        sessionRepository: FakeSessionRepository,
+        settingsRepository: FakeUserSettingsRepository,
+    ): UpdateDiarySyncEnabledUseCase = UpdateDiarySyncEnabledUseCase(
+        sessionRepository = sessionRepository,
+        serverTimeProvider = serverTime,
+        settingsRepository = settingsRepository,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/CheckDiarySyncStateUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/CheckDiarySyncStateUseCaseTest.kt
@@ -1,0 +1,33 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiarySyncStateRepository
+import org.junit.jupiter.api.Test
+
+class CheckDiarySyncStateUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns false when pending count is zero`() {
+        runDomainTest {
+            val syncStateRepository = FakeDiarySyncStateRepository(initialPendingCount = 0)
+            val useCase = CheckDiarySyncStateUseCase(syncStateRepository)
+
+            val result = useCase()
+
+            result.assertOk(false)
+        }
+    }
+
+    @Test
+    fun `returns true when pending count is greater than zero`() {
+        runDomainTest {
+            val syncStateRepository = FakeDiarySyncStateRepository(initialPendingCount = 1)
+            val useCase = CheckDiarySyncStateUseCase(syncStateRepository)
+
+            val result = useCase()
+
+            result.assertOk(true)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/GetInitDiarySyncStateStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/GetInitDiarySyncStateStreamUseCaseTest.kt
@@ -1,0 +1,19 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import kr.co.core.common.state.SyncProcessState
+import kr.co.domain.testing.fake.FakeDiarySyncStateRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetInitDiarySyncStateStreamUseCaseTest {
+
+    @Test
+    fun `returns init diary sync state flow`() {
+        val repository = FakeDiarySyncStateRepository(initialState = SyncProcessState.Completed)
+        val useCase = GetInitDiarySyncStateStreamUseCase(repository)
+
+        val result = useCase()
+
+        assertSame(repository.initDiarySyncState, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/GetMonthSyncStatusStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/GetMonthSyncStatusStreamUseCaseTest.kt
@@ -1,0 +1,23 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import kr.co.core.common.state.SyncStatus
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class GetMonthSyncStatusStreamUseCaseTest {
+
+    @Test
+    fun `returns sync status stream for requested month`() {
+        val repository = FakeDiaryRepository()
+        val useCase = GetMonthSyncStatusStreamUseCase(repository)
+        val target = YearMonth.of(2026, 6)
+        repository.setSyncStatus(target, SyncStatus.SYNCED)
+        val expected = repository.getSyncStatusStream(target)
+
+        val result = useCase(target)
+
+        assertSame(expected, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/InitialDiarySyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/InitialDiarySyncUseCaseTest.kt
@@ -1,0 +1,124 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.state.SyncProcessState
+import kr.co.domain.feature.diary.sync.DiarySyncManager
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiarySyncStateRepository
+import kr.co.domain.testing.fake.FakeSessionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class InitialDiarySyncUseCaseTest : DomainCoroutineTest() {
+
+    private val diarySyncManager = mockk<DiarySyncManager>()
+
+    @Test
+    fun `updates progress and marks completed when initial pull succeeds`() {
+        runDomainTest {
+            val syncStateRepository = FakeDiarySyncStateRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(syncStateRepository, sessionRepository)
+            coEvery {
+                diarySyncManager.performInitialPull(DomainFixtures.UID, any())
+            } answers {
+                @Suppress("UNCHECKED_CAST")
+                val onProgress = args[1] as (Float) -> Unit
+                onProgress(0.25f)
+                onProgress(1f)
+                Ok(Unit)
+            }
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Determinate(0f),
+                    SyncProcessState.InProgress.Determinate(0.25f),
+                    SyncProcessState.InProgress.Determinate(1f),
+                    SyncProcessState.Completed,
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(listOf(true), syncStateRepository.setInitialSyncCompletedCalls)
+            coVerify(exactly = 1) {
+                diarySyncManager.performInitialPull(DomainFixtures.UID, any())
+            }
+        }
+    }
+
+    @Test
+    fun `marks failed and does not pull diaries when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val syncStateRepository = FakeDiarySyncStateRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = createUseCase(syncStateRepository, sessionRepository)
+
+            val result = useCase()
+
+            result.assertErr(error)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Determinate(0f),
+                    SyncProcessState.Failed(error),
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(emptyList<Boolean>(), syncStateRepository.setInitialSyncCompletedCalls)
+            coVerify(exactly = 0) { diarySyncManager.performInitialPull(any(), any()) }
+        }
+    }
+
+    @Test
+    fun `marks failed and does not complete when initial pull fails`() {
+        runDomainTest {
+            val error = DomainError.NetworkUnavailable
+            val syncStateRepository = FakeDiarySyncStateRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(syncStateRepository, sessionRepository)
+            coEvery {
+                diarySyncManager.performInitialPull(DomainFixtures.UID, any())
+            } answers {
+                @Suppress("UNCHECKED_CAST")
+                val onProgress = args[1] as (Float) -> Unit
+                onProgress(0.5f)
+                Err(error)
+            }
+
+            val result = useCase()
+
+            result.assertErr(error)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Determinate(0f),
+                    SyncProcessState.InProgress.Determinate(0.5f),
+                    SyncProcessState.Failed(error),
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(emptyList<Boolean>(), syncStateRepository.setInitialSyncCompletedCalls)
+            coVerify(exactly = 1) {
+                diarySyncManager.performInitialPull(DomainFixtures.UID, any())
+            }
+        }
+    }
+
+    private fun createUseCase(
+        syncStateRepository: FakeDiarySyncStateRepository,
+        sessionRepository: FakeSessionRepository,
+    ): InitialDiarySyncUseCase = InitialDiarySyncUseCase(
+        syncStateRepository = syncStateRepository,
+        sessionRepository = sessionRepository,
+        diarySyncManager = diarySyncManager,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/RequestMonthSyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/RequestMonthSyncUseCaseTest.kt
@@ -1,0 +1,64 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiaryRepository
+import kr.co.domain.testing.fake.FakeSessionRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.time.YearMonth
+
+class RequestMonthSyncUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `requests month sync with current user uid`() {
+        runDomainTest {
+            val diaryRepository = FakeDiaryRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = RequestMonthSyncUseCase(sessionRepository, diaryRepository)
+            val yearMonth = YearMonth.of(2026, 2)
+
+            val result = useCase(yearMonth)
+
+            result.assertOk(Unit)
+            assertEquals(listOf(DomainFixtures.UID to yearMonth), diaryRepository.requestedMonthSyncs)
+        }
+    }
+
+    @Test
+    fun `does not request month sync when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val diaryRepository = FakeDiaryRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = RequestMonthSyncUseCase(sessionRepository, diaryRepository)
+
+            val result = useCase(YearMonth.of(2026, 2))
+
+            result.assertErr(error)
+            assertEquals(emptyList<Pair<String, YearMonth>>(), diaryRepository.requestedMonthSyncs)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when month sync request fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val yearMonth = YearMonth.of(2026, 2)
+            val diaryRepository = FakeDiaryRepository().apply {
+                requestMonthSyncResult = Err(error)
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = RequestMonthSyncUseCase(sessionRepository, diaryRepository)
+
+            val result = useCase(yearMonth)
+
+            result.assertErr(error)
+            assertEquals(listOf(DomainFixtures.UID to yearMonth), diaryRepository.requestedMonthSyncs)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StartDiarySyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StartDiarySyncUseCaseTest.kt
@@ -1,0 +1,77 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.diary.sync.DiarySyncScheduler
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeDiarySyncStateRepository
+import org.junit.jupiter.api.Test
+
+class StartDiarySyncUseCaseTest : DomainCoroutineTest() {
+
+    private val initialDiarySync = mockk<InitialDiarySyncUseCase>()
+    private val diarySyncScheduler = mockk<DiarySyncScheduler>(relaxed = true)
+
+    @Test
+    fun `runs initial sync and schedules periodic sync when initial sync is not completed`() {
+        runDomainTest {
+            val syncStateRepository = FakeDiarySyncStateRepository(initialSyncCompleted = false)
+            val useCase = createUseCase(syncStateRepository)
+            coEvery { initialDiarySync() } returns Ok(Unit)
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            coVerify(exactly = 1) { initialDiarySync() }
+            verify(exactly = 0) { diarySyncScheduler.scheduleFullSync() }
+            verify(exactly = 1) { diarySyncScheduler.schedulePeriodicSync() }
+        }
+    }
+
+    @Test
+    fun `returns initial sync failure and does not schedule sync work`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val syncStateRepository = FakeDiarySyncStateRepository(initialSyncCompleted = false)
+            val useCase = createUseCase(syncStateRepository)
+            coEvery { initialDiarySync() } returns Err(error)
+
+            val result = useCase()
+
+            result.assertErr(error)
+            coVerify(exactly = 1) { initialDiarySync() }
+            verify(exactly = 0) { diarySyncScheduler.scheduleFullSync() }
+            verify(exactly = 0) { diarySyncScheduler.schedulePeriodicSync() }
+        }
+    }
+
+    @Test
+    fun `schedules full and periodic sync when initial sync is completed`() {
+        runDomainTest {
+            val syncStateRepository = FakeDiarySyncStateRepository(initialSyncCompleted = true)
+            val useCase = createUseCase(syncStateRepository)
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            coVerify(exactly = 0) { initialDiarySync() }
+            verify(exactly = 1) { diarySyncScheduler.scheduleFullSync() }
+            verify(exactly = 1) { diarySyncScheduler.schedulePeriodicSync() }
+        }
+    }
+
+    private fun createUseCase(
+        syncStateRepository: FakeDiarySyncStateRepository,
+    ): StartDiarySyncUseCase = StartDiarySyncUseCase(
+        syncStateRepository = syncStateRepository,
+        initialDiarySync = initialDiarySync,
+        diarySyncScheduler = diarySyncScheduler,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StartRealtimeDiarySyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StartRealtimeDiarySyncUseCaseTest.kt
@@ -1,0 +1,45 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kr.co.domain.feature.diary.sync.DiaryRealtimeSyncManager
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class StartRealtimeDiarySyncUseCaseTest : DomainCoroutineTest() {
+
+    private val realtimeSyncManager = mockk<DiaryRealtimeSyncManager>()
+    private val useCase = StartRealtimeDiarySyncUseCase(realtimeSyncManager)
+
+    @Test
+    fun `starts realtime diary sync and returns ok`() {
+        runDomainTest {
+            coEvery { realtimeSyncManager.startListening() } just runs
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            coVerify(exactly = 1) { realtimeSyncManager.startListening() }
+        }
+    }
+
+    @Test
+    fun `propagates start listening exception`() {
+        val exception = IllegalStateException("failure-test")
+        coEvery { realtimeSyncManager.startListening() } throws exception
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase()
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StopDiarySyncUseCasesTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/diary/usecase/sync/StopDiarySyncUseCasesTest.kt
@@ -1,0 +1,62 @@
+package kr.co.domain.feature.diary.usecase.sync
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kr.co.domain.feature.diary.sync.DiaryRealtimeSyncManager
+import kr.co.domain.feature.diary.sync.DiarySyncScheduler
+import org.junit.jupiter.api.Test
+
+class StopDiarySyncUseCasesTest {
+
+    private val scheduler = mockk<DiarySyncScheduler>()
+    private val realtimeSyncManager = mockk<DiaryRealtimeSyncManager>()
+
+    @Test
+    fun `stops realtime diary sync`() {
+        every { realtimeSyncManager.stopListening() } just runs
+        val useCase = StopRealtimeDiarySyncUseCase(realtimeSyncManager)
+
+        useCase()
+
+        verify(exactly = 1) { realtimeSyncManager.stopListening() }
+    }
+
+    @Test
+    fun `cancels diary full sync`() {
+        every { scheduler.cancelFullSync() } just runs
+        val useCase = StopDiaryFullSyncUseCase(scheduler)
+
+        useCase()
+
+        verify(exactly = 1) { scheduler.cancelFullSync() }
+    }
+
+    @Test
+    fun `cancels diary periodic sync`() {
+        every { scheduler.cancelPeriodicSync() } just runs
+        val useCase = StopDiaryPeriodicSyncUseCase(scheduler)
+
+        useCase()
+
+        verify(exactly = 1) { scheduler.cancelPeriodicSync() }
+    }
+
+    @Test
+    fun `cancels all diary sync then stops realtime sync`() {
+        every { scheduler.cancelAllSync() } just runs
+        every { realtimeSyncManager.stopListening() } just runs
+        val stopRealtime = StopRealtimeDiarySyncUseCase(realtimeSyncManager)
+        val useCase = StopAllDiarySyncUseCase(scheduler, stopRealtime)
+
+        useCase()
+
+        verifyOrder {
+            scheduler.cancelAllSync()
+            realtimeSyncManager.stopListening()
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/GetUserProfileStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/GetUserProfileStreamUseCaseTest.kt
@@ -1,0 +1,54 @@
+package kr.co.domain.feature.profile.usecase
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.profile.model.UserProfile
+import kr.co.domain.feature.profile.repository.UserProfileRepository
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetUserProfileStreamUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `removes consecutive duplicate profile emissions`() {
+        runDomainTest {
+            val profile = DomainFixtures.userProfile()
+            val changed = profile.copy(nickname = "nickname-updated-test")
+            val repository = ProfileStreamRepository(
+                flowOf(
+                    Ok(profile),
+                    Ok(profile),
+                    Ok(changed),
+                )
+            )
+            val useCase = GetUserProfileStreamUseCase(repository)
+
+            val result = useCase().toList()
+
+            assertEquals(listOf(Ok(profile), Ok(changed)), result)
+        }
+    }
+
+    private class ProfileStreamRepository(
+        private val stream: Flow<AppResult<UserProfile>>,
+    ) : UserProfileRepository {
+        override suspend fun getUserProfileStream(): Flow<AppResult<UserProfile>> = stream
+
+        override suspend fun updateUserProfile(profile: UserProfile): AppResult<Unit> {
+            error("unused")
+        }
+
+        override suspend fun updateUserProfilePhoto(
+            uid: String,
+            photoUrl: String,
+            lastModifiedAt: Long,
+        ): AppResult<String> {
+            error("unused")
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/GetUserProfileUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/GetUserProfileUseCaseTest.kt
@@ -1,0 +1,40 @@
+package kr.co.domain.feature.profile.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeUserProfileRepository
+import org.junit.jupiter.api.Test
+
+class GetUserProfileUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns first profile stream value`() {
+        runDomainTest {
+            val profile = DomainFixtures.userProfile()
+            val repository = FakeUserProfileRepository(initialProfile = Ok(profile))
+            val useCase = GetUserProfileUseCase(repository)
+
+            val result = useCase()
+
+            result.assertOk(profile)
+        }
+    }
+
+    @Test
+    fun `returns first profile stream failure`() {
+        runDomainTest {
+            val error = DomainError.Store.NotFound
+            val repository = FakeUserProfileRepository(initialProfile = Err(error))
+            val useCase = GetUserProfileUseCase(repository)
+
+            val result = useCase()
+
+            result.assertErr(error)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/UpdateUserProfilePhotoUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/UpdateUserProfilePhotoUseCaseTest.kt
@@ -1,0 +1,86 @@
+package kr.co.domain.feature.profile.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeSessionRepository
+import kr.co.domain.testing.fake.FakeUserProfileRepository
+import kr.co.domain.testing.fake.UserProfilePhotoUpdate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateUserProfilePhotoUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `updates profile photo with current user uid and server time`() {
+        runDomainTest {
+            val profileRepository = FakeUserProfileRepository().apply {
+                updateUserProfilePhotoResult = Ok("updated-photo-url-test")
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, profileRepository)
+
+            val result = useCase("photo-url-test")
+
+            result.assertOk("updated-photo-url-test")
+            assertEquals(
+                listOf(
+                    UserProfilePhotoUpdate(
+                        uid = DomainFixtures.UID,
+                        photoUrl = "photo-url-test",
+                        lastModifiedAt = DomainFixtures.FIXED_TIME,
+                    )
+                ),
+                profileRepository.profilePhotoUpdates,
+            )
+        }
+    }
+
+    @Test
+    fun `does not update profile photo when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val profileRepository = FakeUserProfileRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = createUseCase(sessionRepository, profileRepository)
+
+            val result = useCase("photo-url-test")
+
+            result.assertErr(error)
+            assertEquals(emptyList<UserProfilePhotoUpdate>(), profileRepository.profilePhotoUpdates)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when profile photo update fails`() {
+        runDomainTest {
+            val error = DomainError.Storage.PermissionDenied
+            val profileRepository = FakeUserProfileRepository().apply {
+                updateUserProfilePhotoResult = Err(error)
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, profileRepository)
+
+            val result = useCase("photo-url-test")
+
+            result.assertErr(error)
+            assertEquals(1, profileRepository.profilePhotoUpdates.size)
+        }
+    }
+
+    private fun createUseCase(
+        sessionRepository: FakeSessionRepository,
+        profileRepository: FakeUserProfileRepository,
+    ): UpdateUserProfilePhotoUseCase = UpdateUserProfilePhotoUseCase(
+        sessionRepository = sessionRepository,
+        userProfileRepository = profileRepository,
+        serverTimeProvider = serverTime,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/UpdateUserProfileUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/UpdateUserProfileUseCaseTest.kt
@@ -1,0 +1,82 @@
+package kr.co.domain.feature.profile.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.domain.feature.profile.model.UserProfile
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeSessionRepository
+import kr.co.domain.testing.fake.FakeUserProfileRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateUserProfileUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `updates profile with current user uid and server time`() {
+        runDomainTest {
+            val profileRepository = FakeUserProfileRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, profileRepository)
+            val input = DomainFixtures.userProfile(
+                uid = DomainFixtures.OTHER_UID,
+                lastModifiedAt = 1L,
+            )
+            val expected = input.copy(
+                uid = DomainFixtures.UID,
+                lastModifiedAt = DomainFixtures.FIXED_TIME,
+            )
+
+            val result = useCase(input)
+
+            result.assertOk(Unit)
+            assertEquals(listOf(expected), profileRepository.updatedProfiles)
+        }
+    }
+
+    @Test
+    fun `does not update profile when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val profileRepository = FakeUserProfileRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = createUseCase(sessionRepository, profileRepository)
+
+            val result = useCase(DomainFixtures.userProfile())
+
+            result.assertErr(error)
+            assertEquals(emptyList<UserProfile>(), profileRepository.updatedProfiles)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when profile update fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val profileRepository = FakeUserProfileRepository().apply {
+                updateUserProfileResult = Err(error)
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, profileRepository)
+
+            val result = useCase(DomainFixtures.userProfile())
+
+            result.assertErr(error)
+            assertEquals(1, profileRepository.updatedProfiles.size)
+        }
+    }
+
+    private fun createUseCase(
+        sessionRepository: FakeSessionRepository,
+        profileRepository: FakeUserProfileRepository,
+    ): UpdateUserProfileUseCase = UpdateUserProfileUseCase(
+        sessionRepository = sessionRepository,
+        userProfileRepository = profileRepository,
+        serverTimeProvider = serverTime,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/sync/StartRealtimeUserProfileSyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/sync/StartRealtimeUserProfileSyncUseCaseTest.kt
@@ -1,0 +1,45 @@
+package kr.co.domain.feature.profile.usecase.sync
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kr.co.domain.feature.profile.sync.UserProfileRealtimeSyncScheduler
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class StartRealtimeUserProfileSyncUseCaseTest : DomainCoroutineTest() {
+
+    private val scheduler = mockk<UserProfileRealtimeSyncScheduler>()
+    private val useCase = StartRealtimeUserProfileSyncUseCase(scheduler)
+
+    @Test
+    fun `starts realtime user profile sync and returns ok`() {
+        runDomainTest {
+            coEvery { scheduler.startListening() } just runs
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            coVerify(exactly = 1) { scheduler.startListening() }
+        }
+    }
+
+    @Test
+    fun `propagates start listening exception`() {
+        val exception = IllegalStateException("failure-test")
+        coEvery { scheduler.startListening() } throws exception
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase()
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/profile/usecase/sync/StopUserProfileSyncUseCasesTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/profile/usecase/sync/StopUserProfileSyncUseCasesTest.kt
@@ -1,0 +1,42 @@
+package kr.co.domain.feature.profile.usecase.sync
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kr.co.domain.feature.profile.sync.UserProfileRealtimeSyncScheduler
+import kr.co.domain.feature.profile.sync.UserProfileSyncScheduler
+import org.junit.jupiter.api.Test
+
+class StopUserProfileSyncUseCasesTest {
+
+    private val scheduler = mockk<UserProfileSyncScheduler>()
+    private val realtimeScheduler = mockk<UserProfileRealtimeSyncScheduler>()
+
+    @Test
+    fun `stops realtime user profile sync`() {
+        every { realtimeScheduler.stopListening() } just runs
+        val useCase = StopRealtimeUserProfileSyncUseCase(realtimeScheduler)
+
+        useCase()
+
+        verify(exactly = 1) { realtimeScheduler.stopListening() }
+    }
+
+    @Test
+    fun `cancels all user profile sync then stops realtime sync`() {
+        every { scheduler.cancelAll() } just runs
+        every { realtimeScheduler.stopListening() } just runs
+        val stopRealtime = StopRealtimeUserProfileSyncUseCase(realtimeScheduler)
+        val useCase = StopAllUserProfileSyncUseCase(scheduler, stopRealtime)
+
+        useCase()
+
+        verifyOrder {
+            scheduler.cancelAll()
+            realtimeScheduler.stopListening()
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/search/usecase/AddRecentSearchUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/search/usecase/AddRecentSearchUseCaseTest.kt
@@ -1,0 +1,58 @@
+package kr.co.domain.feature.search.usecase
+
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.fake.FakeSearchRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class AddRecentSearchUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `does not add blank query`() {
+        runDomainTest {
+            val searchRepository = FakeSearchRepository()
+            val useCase = AddRecentSearchUseCase(searchRepository, serverTime)
+
+            useCase("   ")
+
+            assertEquals(emptyList<Pair<String, Long>>(), searchRepository.addedSearches)
+        }
+    }
+
+    @Test
+    fun `adds trimmed query with server time`() {
+        runDomainTest {
+            val searchRepository = FakeSearchRepository()
+            val useCase = AddRecentSearchUseCase(searchRepository, serverTime)
+
+            useCase("  query-test  ")
+
+            assertEquals(
+                listOf("query-test" to DomainFixtures.FIXED_TIME),
+                searchRepository.addedSearches,
+            )
+        }
+    }
+
+    @Test
+    fun `propagates repository exception`() {
+        val exception = IllegalStateException("failure-test")
+        val searchRepository = FakeSearchRepository().apply {
+            addFailure = exception
+        }
+        val useCase = AddRecentSearchUseCase(searchRepository, serverTime)
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase("query-test")
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/search/usecase/ClearAllRecentSearchesUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/search/usecase/ClearAllRecentSearchesUseCaseTest.kt
@@ -1,0 +1,39 @@
+package kr.co.domain.feature.search.usecase
+
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.fake.FakeSearchRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ClearAllRecentSearchesUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `clears all recent searches`() {
+        runDomainTest {
+            val repository = FakeSearchRepository(initialSearches = listOf("query-test"))
+            val useCase = ClearAllRecentSearchesUseCase(repository)
+
+            useCase()
+
+            assertEquals(1, repository.clearAllCallCount)
+        }
+    }
+
+    @Test
+    fun `propagates repository exception`() {
+        val exception = IllegalStateException("failure-test")
+        val repository = FakeSearchRepository().apply {
+            clearFailure = exception
+        }
+        val useCase = ClearAllRecentSearchesUseCase(repository)
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase()
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/search/usecase/GetRecentSearchesUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/search/usecase/GetRecentSearchesUseCaseTest.kt
@@ -1,0 +1,22 @@
+package kr.co.domain.feature.search.usecase
+
+import kotlinx.coroutines.flow.first
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.fake.FakeSearchRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetRecentSearchesUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns recent searches from repository`() {
+        runDomainTest {
+            val repository = FakeSearchRepository(initialSearches = listOf("query-test"))
+            val useCase = GetRecentSearchesUseCase(repository)
+
+            val result = useCase().first()
+
+            assertEquals(listOf("query-test"), result)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/search/usecase/RemoveRecentSearchUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/search/usecase/RemoveRecentSearchUseCaseTest.kt
@@ -1,0 +1,39 @@
+package kr.co.domain.feature.search.usecase
+
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.fake.FakeSearchRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class RemoveRecentSearchUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `removes query from repository`() {
+        runDomainTest {
+            val repository = FakeSearchRepository(initialSearches = listOf("query-test", "other-query-test"))
+            val useCase = RemoveRecentSearchUseCase(repository)
+
+            useCase("query-test")
+
+            assertEquals(listOf("query-test"), repository.removedSearches)
+        }
+    }
+
+    @Test
+    fun `propagates repository exception`() {
+        val exception = IllegalStateException("failure-test")
+        val repository = FakeSearchRepository().apply {
+            removeFailure = exception
+        }
+        val useCase = RemoveRecentSearchUseCase(repository)
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase("query-test")
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/session/usecase/GetCurrentUserUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/session/usecase/GetCurrentUserUseCaseTest.kt
@@ -1,0 +1,40 @@
+package kr.co.domain.feature.session.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeSessionRepository
+import org.junit.jupiter.api.Test
+
+class GetCurrentUserUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns current user from repository`() {
+        runDomainTest {
+            val session = DomainFixtures.userSession()
+            val repository = FakeSessionRepository(currentUserResult = Ok(session))
+            val useCase = GetCurrentUserUseCase(repository)
+
+            val result = useCase()
+
+            result.assertOk(session)
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val repository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = GetCurrentUserUseCase(repository)
+
+            val result = useCase()
+
+            result.assertErr(error)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/session/usecase/GetSessionStateStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/session/usecase/GetSessionStateStreamUseCaseTest.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.feature.session.usecase
+
+import kr.co.domain.testing.fake.FakeSessionRepository
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetSessionStateStreamUseCaseTest {
+
+    @Test
+    fun `returns session state flow`() {
+        val repository = FakeSessionRepository()
+        val useCase = GetSessionStateStreamUseCase(repository)
+
+        val result = useCase()
+
+        assertSame(repository.sessionState, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/session/usecase/ReloadSessionUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/session/usecase/ReloadSessionUseCaseTest.kt
@@ -1,0 +1,40 @@
+package kr.co.domain.feature.session.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeSessionRepository
+import org.junit.jupiter.api.Test
+
+class ReloadSessionUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `returns reloaded session from repository`() {
+        runDomainTest {
+            val session = DomainFixtures.userSession()
+            val repository = FakeSessionRepository(reloadResult = Ok(session))
+            val useCase = ReloadSessionUseCase(repository)
+
+            val result = useCase()
+
+            result.assertOk(session)
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Auth.TokenExpired
+            val repository = FakeSessionRepository(reloadResult = Err(error))
+            val useCase = ReloadSessionUseCase(repository)
+
+            val result = useCase()
+
+            result.assertErr(error)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/setting/usecase/GetAppThemeStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/setting/usecase/GetAppThemeStreamUseCaseTest.kt
@@ -1,0 +1,62 @@
+package kr.co.domain.feature.setting.usecase
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kr.co.core.common.model.AppTheme
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.setting.model.UserSettings
+import kr.co.domain.feature.setting.repository.UserSettingsRepository
+import kr.co.domain.testing.DomainCoroutineTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetAppThemeStreamUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `removes consecutive duplicate app theme emissions`() {
+        runDomainTest {
+            val repository = AppThemeStreamRepository(
+                flowOf(
+                    AppTheme.DARK,
+                    AppTheme.DARK,
+                    AppTheme.LIGHT,
+                )
+            )
+            val useCase = GetAppThemeStreamUseCase(repository)
+
+            val result = useCase().toList()
+
+            assertEquals(listOf(AppTheme.DARK, AppTheme.LIGHT), result)
+        }
+    }
+
+    private class AppThemeStreamRepository(
+        private val appThemeStream: Flow<AppTheme>,
+    ) : UserSettingsRepository {
+        override suspend fun getUserSettingsStream(): Flow<AppResult<UserSettings>> {
+            error("unused")
+        }
+
+        override fun getAppThemeStream(): Flow<AppTheme> = appThemeStream
+
+        override suspend fun updateAppTheme(
+            uid: String,
+            appTheme: AppTheme,
+            lastModifiedAt: Long,
+        ): AppResult<Unit> = Ok(Unit)
+
+        override fun getDiarySyncEnabledStream(): Flow<Boolean> {
+            error("unused")
+        }
+
+        override suspend fun updateDiarySyncEnabled(
+            uid: String,
+            enabled: Boolean,
+            lastModifiedAt: Long,
+        ): AppResult<Unit> {
+            error("unused")
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/setting/usecase/GetUserSettingsStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/setting/usecase/GetUserSettingsStreamUseCaseTest.kt
@@ -1,0 +1,67 @@
+package kr.co.domain.feature.setting.usecase
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kr.co.core.common.model.AppTheme
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.setting.model.UserSettings
+import kr.co.domain.feature.setting.repository.UserSettingsRepository
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class GetUserSettingsStreamUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `removes consecutive duplicate settings emissions`() {
+        runDomainTest {
+            val settings = DomainFixtures.userSettings()
+            val changed = settings.copy(diarySyncEnabled = true)
+            val repository = SettingsStreamRepository(
+                settingsStream = flowOf(
+                    Ok(settings),
+                    Ok(settings),
+                    Ok(changed),
+                )
+            )
+            val useCase = GetUserSettingsStreamUseCase(repository)
+
+            val result = useCase().toList()
+
+            assertEquals(listOf(Ok(settings), Ok(changed)), result)
+        }
+    }
+
+    private class SettingsStreamRepository(
+        private val settingsStream: Flow<AppResult<UserSettings>>,
+    ) : UserSettingsRepository {
+        override suspend fun getUserSettingsStream(): Flow<AppResult<UserSettings>> = settingsStream
+
+        override fun getAppThemeStream(): Flow<AppTheme> {
+            error("unused")
+        }
+
+        override suspend fun updateAppTheme(
+            uid: String,
+            appTheme: AppTheme,
+            lastModifiedAt: Long,
+        ): AppResult<Unit> {
+            error("unused")
+        }
+
+        override fun getDiarySyncEnabledStream(): Flow<Boolean> {
+            error("unused")
+        }
+
+        override suspend fun updateDiarySyncEnabled(
+            uid: String,
+            enabled: Boolean,
+            lastModifiedAt: Long,
+        ): AppResult<Unit> {
+            error("unused")
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/setting/usecase/UpdateAppThemeUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/setting/usecase/UpdateAppThemeUseCaseTest.kt
@@ -1,0 +1,84 @@
+package kr.co.domain.feature.setting.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.model.AppTheme
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.AppThemeUpdate
+import kr.co.domain.testing.fake.FakeSessionRepository
+import kr.co.domain.testing.fake.FakeUserSettingsRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class UpdateAppThemeUseCaseTest : DomainCoroutineTest() {
+
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `updates app theme with current user uid and server time`() {
+        runDomainTest {
+            val settingsRepository = FakeUserSettingsRepository()
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(AppTheme.DARK)
+
+            result.assertOk(Unit)
+            assertEquals(
+                listOf(
+                    AppThemeUpdate(
+                        uid = DomainFixtures.UID,
+                        appTheme = AppTheme.DARK,
+                        lastModifiedAt = DomainFixtures.FIXED_TIME,
+                    )
+                ),
+                settingsRepository.appThemeUpdates,
+            )
+        }
+    }
+
+    @Test
+    fun `does not update app theme when current user lookup fails`() {
+        runDomainTest {
+            val error = DomainError.Auth.UserNotFound
+            val settingsRepository = FakeUserSettingsRepository()
+            val sessionRepository = FakeSessionRepository(currentUserResult = Err(error))
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(AppTheme.LIGHT)
+
+            result.assertErr(error)
+            assertEquals(emptyList<AppThemeUpdate>(), settingsRepository.appThemeUpdates)
+        }
+    }
+
+    @Test
+    fun `returns repository failure when app theme update fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val settingsRepository = FakeUserSettingsRepository().apply {
+                updateAppThemeResult = Err(error)
+            }
+            val sessionRepository = FakeSessionRepository()
+            val useCase = createUseCase(sessionRepository, settingsRepository)
+
+            val result = useCase(AppTheme.LIGHT)
+
+            result.assertErr(error)
+            assertEquals(1, settingsRepository.appThemeUpdates.size)
+        }
+    }
+
+    private fun createUseCase(
+        sessionRepository: FakeSessionRepository,
+        settingsRepository: FakeUserSettingsRepository,
+    ): UpdateAppThemeUseCase = UpdateAppThemeUseCase(
+        sessionRepository = sessionRepository,
+        serverTimeProvider = serverTime,
+        settingsRepository = settingsRepository,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/setting/usecase/sync/StartRealtimeUserSettingsSyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/setting/usecase/sync/StartRealtimeUserSettingsSyncUseCaseTest.kt
@@ -1,0 +1,45 @@
+package kr.co.domain.feature.setting.usecase.sync
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kr.co.domain.feature.setting.sync.UserSettingsRealtimeSyncScheduler
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class StartRealtimeUserSettingsSyncUseCaseTest : DomainCoroutineTest() {
+
+    private val scheduler = mockk<UserSettingsRealtimeSyncScheduler>()
+    private val useCase = StartRealtimeUserSettingsSyncUseCase(scheduler)
+
+    @Test
+    fun `starts realtime user settings sync and returns ok`() {
+        runDomainTest {
+            coEvery { scheduler.startListening() } just runs
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            coVerify(exactly = 1) { scheduler.startListening() }
+        }
+    }
+
+    @Test
+    fun `propagates start listening exception`() {
+        val exception = IllegalStateException("failure-test")
+        coEvery { scheduler.startListening() } throws exception
+
+        val actual = assertThrows(IllegalStateException::class.java) {
+            runDomainTest {
+                useCase()
+            }
+        }
+
+        assertEquals(exception, actual)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/setting/usecase/sync/StopUserSettingsSyncUseCasesTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/setting/usecase/sync/StopUserSettingsSyncUseCasesTest.kt
@@ -1,0 +1,42 @@
+package kr.co.domain.feature.setting.usecase.sync
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kr.co.domain.feature.setting.sync.UserSettingsRealtimeSyncScheduler
+import kr.co.domain.feature.setting.sync.UserSettingsSyncScheduler
+import org.junit.jupiter.api.Test
+
+class StopUserSettingsSyncUseCasesTest {
+
+    private val scheduler = mockk<UserSettingsSyncScheduler>()
+    private val realtimeScheduler = mockk<UserSettingsRealtimeSyncScheduler>()
+
+    @Test
+    fun `stops realtime user settings sync`() {
+        every { realtimeScheduler.stopListening() } just runs
+        val useCase = StopRealtimeUserSettingsSyncUseCase(realtimeScheduler)
+
+        useCase()
+
+        verify(exactly = 1) { realtimeScheduler.stopListening() }
+    }
+
+    @Test
+    fun `cancels all user settings sync then stops realtime sync`() {
+        every { scheduler.cancelAll() } just runs
+        every { realtimeScheduler.stopListening() } just runs
+        val stopRealtime = StopRealtimeUserSettingsSyncUseCase(realtimeScheduler)
+        val useCase = StopAllUserSettingsSyncUseCase(scheduler, stopRealtime)
+
+        useCase()
+
+        verifyOrder {
+            scheduler.cancelAll()
+            realtimeScheduler.stopListening()
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/time/usecase/SyncServerTimeUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/time/usecase/SyncServerTimeUseCaseTest.kt
@@ -1,0 +1,48 @@
+package kr.co.domain.feature.time.usecase
+
+import com.github.michaelbull.result.Err
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import kr.co.core.common.error.DomainError
+import kr.co.domain.service.time.ServerTimeSyncScheduler
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import org.junit.jupiter.api.Test
+
+class SyncServerTimeUseCaseTest : DomainCoroutineTest() {
+
+    private val scheduler = mockk<ServerTimeSyncScheduler>()
+
+    @Test
+    fun `does not schedule sync when server time sync succeeds`() {
+        runDomainTest {
+            val serverTime = FakeServerTimeProvider()
+            val useCase = SyncServerTimeUseCase(serverTime, scheduler)
+
+            val result = useCase()
+
+            result.assertOk(Unit)
+            verify(exactly = 0) { scheduler.scheduleSync() }
+        }
+    }
+
+    @Test
+    fun `schedules sync when server time sync fails`() {
+        runDomainTest {
+            val error = DomainError.NetworkUnavailable
+            val serverTime = FakeServerTimeProvider(syncResult = Err(error))
+            every { scheduler.scheduleSync() } just runs
+            val useCase = SyncServerTimeUseCase(serverTime, scheduler)
+
+            val result = useCase()
+
+            result.assertErr(error)
+            verify(exactly = 1) { scheduler.scheduleSync() }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/user/usecase/DeleteUserStorageUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/user/usecase/DeleteUserStorageUseCaseTest.kt
@@ -1,0 +1,41 @@
+package kr.co.domain.feature.user.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeUserStorageRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeleteUserStorageUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `deletes storage for requested uid`() {
+        runDomainTest {
+            val repository = FakeUserStorageRepository()
+            val useCase = DeleteUserStorageUseCase(repository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(listOf(DomainFixtures.UID), repository.deletedUids)
+        }
+    }
+
+    @Test
+    fun `returns repository failure`() {
+        runDomainTest {
+            val error = DomainError.Storage.PermissionDenied
+            val repository = FakeUserStorageRepository(deleteUserStorageResult = Err(error))
+            val useCase = DeleteUserStorageUseCase(repository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertErr(error)
+            assertEquals(listOf(DomainFixtures.UID), repository.deletedUids)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/feature/user/usecase/InitUserStorageUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/user/usecase/InitUserStorageUseCaseTest.kt
@@ -1,0 +1,87 @@
+package kr.co.domain.feature.user.usecase
+
+import com.github.michaelbull.result.Err
+import kr.co.core.common.error.DomainError
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeSessionRepository
+import kr.co.domain.testing.fake.FakeUserStorageRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class InitUserStorageUseCaseTest : DomainCoroutineTest() {
+
+    @Test
+    fun `stores current uid without deleting storage when last uid is null`() {
+        runDomainTest {
+            val sessionRepository = FakeSessionRepository(initialLastSignInUid = null)
+            val userStorageRepository = FakeUserStorageRepository()
+            val useCase = createUseCase(sessionRepository, userStorageRepository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(emptyList<String>(), userStorageRepository.deletedUids)
+            assertEquals(listOf(DomainFixtures.UID), sessionRepository.setLastSignInUidCalls)
+            assertEquals(DomainFixtures.UID, sessionRepository.lastSignInUid)
+        }
+    }
+
+    @Test
+    fun `does not delete storage when last uid is the same as current uid`() {
+        runDomainTest {
+            val sessionRepository = FakeSessionRepository(initialLastSignInUid = DomainFixtures.UID)
+            val userStorageRepository = FakeUserStorageRepository()
+            val useCase = createUseCase(sessionRepository, userStorageRepository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(emptyList<String>(), userStorageRepository.deletedUids)
+            assertEquals(listOf(DomainFixtures.UID), sessionRepository.setLastSignInUidCalls)
+        }
+    }
+
+    @Test
+    fun `deletes previous user storage and stores current uid when last uid is different`() {
+        runDomainTest {
+            val sessionRepository = FakeSessionRepository(initialLastSignInUid = DomainFixtures.OTHER_UID)
+            val userStorageRepository = FakeUserStorageRepository()
+            val useCase = createUseCase(sessionRepository, userStorageRepository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(listOf(DomainFixtures.OTHER_UID), userStorageRepository.deletedUids)
+            assertEquals(listOf(DomainFixtures.UID), sessionRepository.setLastSignInUidCalls)
+            assertEquals(DomainFixtures.UID, sessionRepository.lastSignInUid)
+        }
+    }
+
+    @Test
+    fun `returns deletion failure and does not store current uid when previous storage deletion fails`() {
+        runDomainTest {
+            val error = DomainError.Storage.PermissionDenied
+            val sessionRepository = FakeSessionRepository(initialLastSignInUid = DomainFixtures.OTHER_UID)
+            val userStorageRepository = FakeUserStorageRepository(deleteUserStorageResult = Err(error))
+            val useCase = createUseCase(sessionRepository, userStorageRepository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertErr(error)
+            assertEquals(listOf(DomainFixtures.OTHER_UID), userStorageRepository.deletedUids)
+            assertEquals(emptyList<String>(), sessionRepository.setLastSignInUidCalls)
+            assertEquals(DomainFixtures.OTHER_UID, sessionRepository.lastSignInUid)
+        }
+    }
+
+    private fun createUseCase(
+        sessionRepository: FakeSessionRepository,
+        userStorageRepository: FakeUserStorageRepository,
+    ): InitUserStorageUseCase = InitUserStorageUseCase(
+        sessionRepository = sessionRepository,
+        deleteUserStorage = DeleteUserStorageUseCase(userStorageRepository),
+    )
+}

--- a/domain/src/test/java/kr/co/domain/feature/user/usecase/StartUserDataSyncUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/feature/user/usecase/StartUserDataSyncUseCaseTest.kt
@@ -1,0 +1,126 @@
+package kr.co.domain.feature.user.usecase
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.state.SyncProcessState
+import kr.co.domain.feature.profile.sync.UserProfileSyncManager
+import kr.co.domain.feature.setting.sync.UserSettingsSyncManager
+import kr.co.domain.testing.DomainCoroutineTest
+import kr.co.domain.testing.DomainFixtures
+import kr.co.domain.testing.FakeServerTimeProvider
+import kr.co.domain.testing.assertErr
+import kr.co.domain.testing.assertOk
+import kr.co.domain.testing.fake.FakeUserDataSyncStateRepository
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class StartUserDataSyncUseCaseTest : DomainCoroutineTest() {
+
+    private val userProfileSyncManager = mockk<UserProfileSyncManager>()
+    private val userSettingsSyncManager = mockk<UserSettingsSyncManager>()
+    private val serverTime = FakeServerTimeProvider(currentTime = DomainFixtures.FIXED_TIME)
+
+    @Test
+    fun `does not start sync managers when last sync is within interval`() {
+        runDomainTest {
+            val syncStateRepository = FakeUserDataSyncStateRepository(
+                initialLastSyncTimestamp = DomainFixtures.FIXED_TIME - 1_000L,
+            )
+            val useCase = createUseCase(syncStateRepository)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(emptyList<Long>(), syncStateRepository.savedTimestamps)
+            coVerify(exactly = 0) { userProfileSyncManager.syncProfile(any()) }
+            coVerify(exactly = 0) { userSettingsSyncManager.syncSettings(any()) }
+        }
+    }
+
+    @Test
+    fun `updates state and saves timestamp when profile and settings sync succeed`() {
+        runDomainTest {
+            val syncStateRepository = FakeUserDataSyncStateRepository()
+            val useCase = createUseCase(syncStateRepository)
+            coEvery { userProfileSyncManager.syncProfile(DomainFixtures.UID) } returns Ok(Unit)
+            coEvery { userSettingsSyncManager.syncSettings(DomainFixtures.UID) } returns Ok(Unit)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertOk(Unit)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Indeterminate,
+                    SyncProcessState.Completed,
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(listOf(DomainFixtures.FIXED_TIME), syncStateRepository.savedTimestamps)
+            coVerify(exactly = 1) { userProfileSyncManager.syncProfile(DomainFixtures.UID) }
+            coVerify(exactly = 1) { userSettingsSyncManager.syncSettings(DomainFixtures.UID) }
+        }
+    }
+
+    @Test
+    fun `marks failed and does not save timestamp when profile sync fails`() {
+        runDomainTest {
+            val error = DomainError.Store.PermissionDenied
+            val syncStateRepository = FakeUserDataSyncStateRepository()
+            val useCase = createUseCase(syncStateRepository)
+            coEvery { userProfileSyncManager.syncProfile(DomainFixtures.UID) } returns Err(error)
+            coEvery { userSettingsSyncManager.syncSettings(DomainFixtures.UID) } returns Ok(Unit)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertErr(error)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Indeterminate,
+                    SyncProcessState.Failed(error),
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(emptyList<Long>(), syncStateRepository.savedTimestamps)
+            coVerify(exactly = 1) { userProfileSyncManager.syncProfile(DomainFixtures.UID) }
+            coVerify(exactly = 1) { userSettingsSyncManager.syncSettings(DomainFixtures.UID) }
+        }
+    }
+
+    @Test
+    fun `marks failed and does not save timestamp when settings sync fails`() {
+        runDomainTest {
+            val error = DomainError.Store.Unauthenticated
+            val syncStateRepository = FakeUserDataSyncStateRepository()
+            val useCase = createUseCase(syncStateRepository)
+            coEvery { userProfileSyncManager.syncProfile(DomainFixtures.UID) } returns Ok(Unit)
+            coEvery { userSettingsSyncManager.syncSettings(DomainFixtures.UID) } returns Err(error)
+
+            val result = useCase(DomainFixtures.UID)
+
+            result.assertErr(error)
+            assertEquals(
+                listOf(
+                    SyncProcessState.InProgress.Indeterminate,
+                    SyncProcessState.Failed(error),
+                ),
+                syncStateRepository.stateUpdates,
+            )
+            assertEquals(emptyList<Long>(), syncStateRepository.savedTimestamps)
+            coVerify(exactly = 1) { userProfileSyncManager.syncProfile(DomainFixtures.UID) }
+            coVerify(exactly = 1) { userSettingsSyncManager.syncSettings(DomainFixtures.UID) }
+        }
+    }
+
+    private fun createUseCase(
+        syncStateRepository: FakeUserDataSyncStateRepository,
+    ): StartUserDataSyncUseCase = StartUserDataSyncUseCase(
+        userProfileSyncManager = userProfileSyncManager,
+        userSettingsSyncManager = userSettingsSyncManager,
+        userDataSyncStateRepository = syncStateRepository,
+        serverTime = serverTime,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/service/network/usecase/GetNetworkStatusStreamUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/service/network/usecase/GetNetworkStatusStreamUseCaseTest.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.service.network.usecase
+
+import kr.co.domain.testing.fake.FakeNetworkMonitor
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class GetNetworkStatusStreamUseCaseTest {
+
+    @Test
+    fun `returns network status flow`() {
+        val networkMonitor = FakeNetworkMonitor(initialOnline = true)
+        val useCase = GetNetworkStatusStreamUseCase(networkMonitor)
+
+        val result = useCase()
+
+        assertSame(networkMonitor.isOnline, result)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/service/remoteconfig/usecase/CheckServiceStatusUseCaseTest.kt
+++ b/domain/src/test/java/kr/co/domain/service/remoteconfig/usecase/CheckServiceStatusUseCaseTest.kt
@@ -1,0 +1,50 @@
+package kr.co.domain.service.remoteconfig.usecase
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kr.co.domain.service.remoteconfig.model.ServiceStatus
+import kr.co.domain.service.remoteconfig.repository.RemoteConfigRepository
+import kr.co.domain.testing.DomainCoroutineTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class CheckServiceStatusUseCaseTest : DomainCoroutineTest() {
+
+    private val repository = mockk<RemoteConfigRepository>()
+    private val useCase = CheckServiceStatusUseCase(repository)
+
+    @Test
+    fun `returns active status after fetch when maintenance mode is disabled`() {
+        runDomainTest {
+            coEvery { repository.fetchAndActivate() } returns true
+            every { repository.isMaintenanceMode() } returns false
+
+            val result = useCase()
+
+            assertSame(ServiceStatus.Active, result)
+            coVerify(exactly = 1) { repository.fetchAndActivate() }
+            verify(exactly = 1) { repository.isMaintenanceMode() }
+            verify(exactly = 0) { repository.getMaintenanceReason() }
+        }
+    }
+
+    @Test
+    fun `returns maintenance status with reason after fetch when maintenance mode is enabled`() {
+        runDomainTest {
+            coEvery { repository.fetchAndActivate() } returns true
+            every { repository.isMaintenanceMode() } returns true
+            every { repository.getMaintenanceReason() } returns "reason-test"
+
+            val result = useCase()
+
+            assertEquals(ServiceStatus.Maintenance("reason-test"), result)
+            coVerify(exactly = 1) { repository.fetchAndActivate() }
+            verify(exactly = 1) { repository.isMaintenanceMode() }
+            verify(exactly = 1) { repository.getMaintenanceReason() }
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/DomainCoroutineTest.kt
+++ b/domain/src/test/java/kr/co/domain/testing/DomainCoroutineTest.kt
@@ -1,0 +1,31 @@
+package kr.co.domain.testing
+
+import io.mockk.clearAllMocks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+
+@OptIn(ExperimentalCoroutinesApi::class)
+abstract class DomainCoroutineTest {
+    protected val testDispatcher = StandardTestDispatcher()
+
+    @BeforeEach
+    fun setUpCoroutine() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDownCoroutine() {
+        Dispatchers.resetMain()
+        clearAllMocks()
+    }
+
+    protected fun runDomainTest(block: suspend TestScope.() -> Unit) =
+        runTest(testDispatcher) { block() }
+}

--- a/domain/src/test/java/kr/co/domain/testing/DomainFixtures.kt
+++ b/domain/src/test/java/kr/co/domain/testing/DomainFixtures.kt
@@ -1,0 +1,100 @@
+package kr.co.domain.testing
+
+import kr.co.core.common.model.AppTheme
+import kr.co.core.common.model.Emotion
+import kr.co.core.common.model.Gender
+import kr.co.core.common.state.DiarySyncStatus
+import kr.co.domain.feature.account.model.Account
+import kr.co.domain.feature.account.model.SignUpInfo
+import kr.co.domain.feature.diary.model.Diary
+import kr.co.domain.feature.profile.model.UserProfile
+import kr.co.domain.feature.session.model.UserSession
+import kr.co.domain.feature.setting.model.UserSettings
+import java.time.LocalDate
+
+object DomainFixtures {
+    const val UID = "uid-test"
+    const val OTHER_UID = "uid-other"
+    const val EMAIL = "email-test"
+    const val FIXED_TIME = 1_700_000_000_000L
+
+    val DATE: LocalDate = LocalDate.of(2026, 1, 15)
+    val BIRTHDAY: LocalDate = LocalDate.of(2000, 1, 1)
+
+    fun account(
+        uid: String = UID,
+        email: String = EMAIL,
+    ): Account = Account(
+        uid = uid,
+        email = email,
+    )
+
+    fun signUpInfo(
+        email: String = EMAIL,
+        name: String = "name-test",
+    ): SignUpInfo = SignUpInfo(
+        email = email,
+        password = "value-test",
+        name = name,
+        gender = Gender.NONE,
+        birthday = BIRTHDAY,
+        address = "address-test",
+        phoneNumber = "phone-test",
+    )
+
+    fun userSession(
+        uid: String = UID,
+        email: String = EMAIL,
+    ): UserSession = UserSession(
+        uid = uid,
+        email = email,
+    )
+
+    fun diary(
+        id: String = "diary-id-test",
+        date: LocalDate = DATE,
+        title: String = "title-test",
+        content: String = "",
+        createdAt: Long = FIXED_TIME,
+        updatedAt: Long = FIXED_TIME,
+        syncStatus: DiarySyncStatus = DiarySyncStatus.SYNCED,
+    ): Diary = Diary(
+        id = id,
+        date = date,
+        title = title,
+        content = content,
+        emotions = listOf(Emotion.CALMNESS),
+        imageUrls = emptyList(),
+        createdAt = createdAt,
+        updatedAt = updatedAt,
+        syncStatus = syncStatus,
+    )
+
+    fun userProfile(
+        uid: String = UID,
+        email: String = EMAIL,
+        lastModifiedAt: Long = FIXED_TIME,
+    ): UserProfile = UserProfile(
+        uid = uid,
+        email = email,
+        name = "name-test",
+        gender = Gender.NONE,
+        birthday = BIRTHDAY,
+        address = "address-test",
+        phoneNumber = "phone-test",
+        nickname = "nickname-test",
+        profilePhotoUrl = "photo-url-test",
+        joinedAt = FIXED_TIME,
+        lastModifiedAt = lastModifiedAt,
+    )
+
+    fun userSettings(
+        appTheme: AppTheme = AppTheme.SYSTEM,
+        diarySyncEnabled: Boolean = false,
+        lastModifiedAt: Long = FIXED_TIME,
+    ): UserSettings = UserSettings(
+        appTheme = appTheme,
+        diarySyncEnabled = diarySyncEnabled,
+        lastModifiedAt = lastModifiedAt,
+    )
+}

--- a/domain/src/test/java/kr/co/domain/testing/DomainResultAssertions.kt
+++ b/domain/src/test/java/kr/co/domain/testing/DomainResultAssertions.kt
@@ -1,0 +1,35 @@
+package kr.co.domain.testing
+
+import com.github.michaelbull.result.annotation.UnsafeResultErrorAccess
+import com.github.michaelbull.result.annotation.UnsafeResultValueAccess
+import kr.co.core.common.error.DomainError
+import kr.co.core.common.result.AppResult
+import org.junit.jupiter.api.Assertions.assertEquals
+
+@OptIn(UnsafeResultValueAccess::class, UnsafeResultErrorAccess::class)
+fun <T> AppResult<T>.assertOk(): T =
+    when {
+        isOk -> value
+        isErr -> throw AssertionError("Expected Ok but was Err($error)")
+        else -> throw AssertionError("Expected Ok but result state was unknown")
+    }
+
+fun <T> AppResult<T>.assertOk(expected: T): T {
+    val actual = assertOk()
+    assertEquals(expected, actual)
+    return actual
+}
+
+@OptIn(UnsafeResultValueAccess::class, UnsafeResultErrorAccess::class)
+fun <T> AppResult<T>.assertErr(): DomainError =
+    when {
+        isErr -> error
+        isOk -> throw AssertionError("Expected Err but was Ok($value)")
+        else -> throw AssertionError("Expected Err but result state was unknown")
+    }
+
+fun <T> AppResult<T>.assertErr(expected: DomainError): DomainError {
+    val actual = assertErr()
+    assertEquals(expected, actual)
+    return actual
+}

--- a/domain/src/test/java/kr/co/domain/testing/DomainTestingInfrastructureTest.kt
+++ b/domain/src/test/java/kr/co/domain/testing/DomainTestingInfrastructureTest.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.testing
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DomainTestingInfrastructureTest : DomainCoroutineTest() {
+
+    @Test
+    fun `runDomainTest executes with fake server time`() {
+        runDomainTest {
+            val serverTime = FakeServerTimeProvider(currentTime = 42L)
+
+            assertEquals(42L, serverTime.now())
+            serverTime.sync().assertOk(Unit)
+            assertEquals(1, serverTime.syncCallCount)
+        }
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/FakeServerTimeProvider.kt
+++ b/domain/src/test/java/kr/co/domain/testing/FakeServerTimeProvider.kt
@@ -1,0 +1,20 @@
+package kr.co.domain.testing
+
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.result.AppResult
+import kr.co.domain.service.time.ServerTimeProvider
+
+class FakeServerTimeProvider(
+    var currentTime: Long = DomainFixtures.FIXED_TIME,
+    var syncResult: AppResult<Unit> = Ok(Unit),
+) : ServerTimeProvider {
+    var syncCallCount = 0
+        private set
+
+    override suspend fun sync(): AppResult<Unit> {
+        syncCallCount += 1
+        return syncResult
+    }
+
+    override fun now(): Long = currentTime
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeCalendarRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeCalendarRepository.kt
@@ -1,0 +1,27 @@
+package kr.co.domain.testing.fake
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.domain.feature.calendar.model.CalendarMonth
+import kr.co.domain.feature.calendar.repository.CalendarRepository
+import java.time.Year
+import java.time.YearMonth
+
+class FakeCalendarRepository : CalendarRepository {
+    val yearlyPagesFlow = MutableStateFlow<PagingData<CalendarMonth>>(PagingData.empty())
+    val monthlyPagesFlow = MutableStateFlow<PagingData<CalendarMonth>>(PagingData.empty())
+
+    val requestedYears = mutableListOf<Year>()
+    val requestedYearMonths = mutableListOf<YearMonth>()
+
+    override fun getYearlyPages(targetYear: Year): Flow<PagingData<CalendarMonth>> {
+        requestedYears += targetYear
+        return yearlyPagesFlow
+    }
+
+    override fun getMonthlyPages(targetYearMonth: YearMonth): Flow<PagingData<CalendarMonth>> {
+        requestedYearMonths += targetYearMonth
+        return monthlyPagesFlow
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeDashboardRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeDashboardRepository.kt
@@ -1,0 +1,18 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.dashboard.model.Dashboard
+import kr.co.domain.feature.dashboard.repository.DashboardRepository
+
+class FakeDashboardRepository(
+    var dashboardResult: AppResult<Dashboard> = Ok(Dashboard()),
+) : DashboardRepository {
+    var getDashboardCallCount = 0
+        private set
+
+    override suspend fun getDashboard(): AppResult<Dashboard> {
+        getDashboardCallCount += 1
+        return dashboardResult
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeDiaryRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeDiaryRepository.kt
@@ -1,0 +1,139 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.core.common.result.AppResult
+import kr.co.core.common.state.SyncStatus
+import kr.co.domain.feature.diary.model.Diary
+import kr.co.domain.feature.diary.repository.DiaryRepository
+import java.time.LocalDate
+import java.time.YearMonth
+
+data class PagedDiariesRequest(
+    val query: String?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val limit: Int,
+    val offset: Int,
+)
+
+class FakeDiaryRepository(
+    initialDiaries: List<Diary> = emptyList(),
+) : DiaryRepository {
+    private val diariesByDate = initialDiaries.associateBy { it.date }.toMutableMap()
+    private val diaryStreams = mutableMapOf<LocalDate, MutableStateFlow<Diary?>>()
+    private val syncStatusStreams = mutableMapOf<YearMonth, MutableStateFlow<SyncStatus>>()
+    private val dateRangeStream = MutableStateFlow(initialDiaries)
+    private val diaryChangeEvents = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    val requestedMonthSyncs = mutableListOf<Pair<String, YearMonth>>()
+    val createdDiaries = mutableListOf<Diary>()
+    val updatedDiaries = mutableListOf<Diary>()
+    val deletedDiaries = mutableListOf<Diary>()
+    val requestedDateRanges = mutableListOf<Pair<LocalDate, LocalDate>>()
+    val pagedDiaryRequests = mutableListOf<PagedDiariesRequest>()
+
+    var requestMonthSyncResult: AppResult<Unit> = Ok(Unit)
+    var createDiaryResult: AppResult<Unit> = Ok(Unit)
+    var updateDiaryResult: AppResult<Diary>? = null
+    var deleteDiaryResult: AppResult<Unit> = Ok(Unit)
+    var deleteOldDiariesResult: AppResult<Unit> = Ok(Unit)
+    var getDiaryResult: AppResult<Diary?>? = null
+    var getDiariesByDateRangeResult: AppResult<List<Diary>> = Ok(initialDiaries)
+    var getPagedDiariesResult: AppResult<List<Diary>> = Ok(initialDiaries)
+
+    override fun getSyncStatusStream(yearMonth: YearMonth): Flow<SyncStatus> =
+        syncStatusStreams.getOrPut(yearMonth) { MutableStateFlow(SyncStatus.IDLE) }
+
+    fun setSyncStatus(yearMonth: YearMonth, status: SyncStatus) {
+        syncStatusStreams.getOrPut(yearMonth) { MutableStateFlow(SyncStatus.IDLE) }.value = status
+    }
+
+    override suspend fun requestMonthSync(userId: String, yearMonth: YearMonth): AppResult<Unit> {
+        requestedMonthSyncs += userId to yearMonth
+        return requestMonthSyncResult
+    }
+
+    override suspend fun createDiary(diary: Diary): AppResult<Unit> {
+        createdDiaries += diary
+        diariesByDate[diary.date] = diary
+        diaryStreams[diary.date]?.value = diary
+        return createDiaryResult
+    }
+
+    override suspend fun updateDiary(diary: Diary): AppResult<Diary> {
+        updatedDiaries += diary
+        diariesByDate[diary.date] = diary
+        diaryStreams[diary.date]?.value = diary
+        return updateDiaryResult ?: Ok(diary)
+    }
+
+    override suspend fun deleteDiary(diary: Diary): AppResult<Unit> {
+        deletedDiaries += diary
+        diariesByDate.remove(diary.date)
+        diaryStreams[diary.date]?.value = null
+        return deleteDiaryResult
+    }
+
+    override suspend fun deleteOldDiaries(): AppResult<Unit> = deleteOldDiariesResult
+
+    override suspend fun getDiary(date: LocalDate): AppResult<Diary?> =
+        getDiaryResult ?: Ok(diariesByDate[date])
+
+    override fun getDiaryStream(date: LocalDate): Flow<Diary?> =
+        diaryStreams.getOrPut(date) { MutableStateFlow(diariesByDate[date]) }
+
+    fun emitDiary(date: LocalDate, diary: Diary?) {
+        if (diary == null) {
+            diariesByDate.remove(date)
+        } else {
+            diariesByDate[date] = diary
+        }
+        diaryStreams.getOrPut(date) { MutableStateFlow(null) }.value = diary
+    }
+
+    override fun getDiariesByDateRangeStream(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): Flow<List<Diary>> {
+        requestedDateRanges += startDate to endDate
+        return dateRangeStream
+    }
+
+    fun emitDateRangeDiaries(diaries: List<Diary>) {
+        dateRangeStream.value = diaries
+    }
+
+    override suspend fun getDiariesByDateRange(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): AppResult<List<Diary>> {
+        requestedDateRanges += startDate to endDate
+        return getDiariesByDateRangeResult
+    }
+
+    override suspend fun getPagedDiaries(
+        query: String?,
+        startDate: LocalDate?,
+        endDate: LocalDate?,
+        limit: Int,
+        offset: Int,
+    ): AppResult<List<Diary>> {
+        pagedDiaryRequests += PagedDiariesRequest(
+            query = query,
+            startDate = startDate,
+            endDate = endDate,
+            limit = limit,
+            offset = offset,
+        )
+        return getPagedDiariesResult
+    }
+
+    override val diaryChangeEvent: Flow<Unit> = diaryChangeEvents
+
+    fun emitDiaryChange() {
+        diaryChangeEvents.tryEmit(Unit)
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeDiarySyncStateRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeDiarySyncStateRepository.kt
@@ -1,0 +1,40 @@
+package kr.co.domain.testing.fake
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kr.co.core.common.state.SyncProcessState
+import kr.co.domain.feature.diary.sync.DiarySyncStateRepository
+
+class FakeDiarySyncStateRepository(
+    initialState: SyncProcessState = SyncProcessState.Idle,
+    initialPendingCount: Int = 0,
+    initialSyncCompleted: Boolean = false,
+) : DiarySyncStateRepository {
+    private val state = MutableStateFlow(initialState)
+    private val pendingCountState = MutableStateFlow(initialPendingCount)
+
+    val stateUpdates = mutableListOf<SyncProcessState>()
+    val setInitialSyncCompletedCalls = mutableListOf<Boolean>()
+
+    var initialSyncCompleted: Boolean = initialSyncCompleted
+
+    override val initDiarySyncState: StateFlow<SyncProcessState> = state
+    override val pendingCount: Flow<Int> = pendingCountState
+
+    fun setPendingCount(count: Int) {
+        pendingCountState.value = count
+    }
+
+    override fun updateInitDiarySyncState(state: SyncProcessState) {
+        stateUpdates += state
+        this.state.value = state
+    }
+
+    override suspend fun isInitialSyncCompleted(): Boolean = initialSyncCompleted
+
+    override suspend fun setInitialSyncCompleted(completed: Boolean) {
+        setInitialSyncCompletedCalls += completed
+        initialSyncCompleted = completed
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeNetworkMonitor.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeNetworkMonitor.kt
@@ -1,0 +1,10 @@
+package kr.co.domain.testing.fake
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.domain.service.network.NetworkMonitor
+
+class FakeNetworkMonitor(
+    initialOnline: Boolean = false,
+) : NetworkMonitor {
+    override val isOnline = MutableStateFlow(initialOnline)
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeSearchRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeSearchRepository.kt
@@ -1,0 +1,39 @@
+package kr.co.domain.testing.fake
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.domain.feature.search.repository.SearchRepository
+
+class FakeSearchRepository(
+    initialSearches: List<String> = emptyList(),
+) : SearchRepository {
+    private val recentSearches = MutableStateFlow(initialSearches)
+
+    val addedSearches = mutableListOf<Pair<String, Long>>()
+    val removedSearches = mutableListOf<String>()
+    var clearAllCallCount = 0
+
+    var addFailure: Throwable? = null
+    var removeFailure: Throwable? = null
+    var clearFailure: Throwable? = null
+
+    override fun getRecentSearches(): Flow<List<String>> = recentSearches
+
+    override suspend fun addRecentSearch(query: String, timestamp: Long) {
+        addFailure?.let { throw it }
+        addedSearches += query to timestamp
+        recentSearches.value = listOf(query) + recentSearches.value.filterNot { it == query }
+    }
+
+    override suspend fun removeRecentSearch(query: String) {
+        removeFailure?.let { throw it }
+        removedSearches += query
+        recentSearches.value = recentSearches.value.filterNot { it == query }
+    }
+
+    override suspend fun clearAll() {
+        clearFailure?.let { throw it }
+        clearAllCallCount += 1
+        recentSearches.value = emptyList()
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeSessionRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeSessionRepository.kt
@@ -1,0 +1,34 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.session.model.UserSession
+import kr.co.domain.feature.session.repository.SessionRepository
+import kr.co.domain.testing.DomainFixtures
+
+class FakeSessionRepository(
+    initialSession: UserSession? = DomainFixtures.userSession(),
+    initialLastSignInUid: String? = null,
+    var currentUserResult: AppResult<UserSession> = Ok(DomainFixtures.userSession()),
+    var reloadResult: AppResult<UserSession> = Ok(DomainFixtures.userSession()),
+) : SessionRepository {
+    val sessionState = MutableStateFlow(initialSession)
+    val setLastSignInUidCalls = mutableListOf<String>()
+
+    var lastSignInUid: String? = initialLastSignInUid
+
+    override suspend fun getLastSignInUid(): String? = lastSignInUid
+
+    override suspend fun setLastSignInUid(uid: String) {
+        setLastSignInUidCalls += uid
+        lastSignInUid = uid
+    }
+
+    override suspend fun getCurrentUser(): AppResult<UserSession> = currentUserResult
+
+    override suspend fun reload(): AppResult<UserSession> = reloadResult
+
+    override fun getSessionStateStream(): Flow<UserSession?> = sessionState
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeUserDataSyncStateRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeUserDataSyncStateRepository.kt
@@ -1,0 +1,32 @@
+package kr.co.domain.testing.fake
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kr.co.core.common.state.SyncProcessState
+import kr.co.domain.feature.user.repository.UserDataSyncStateRepository
+
+class FakeUserDataSyncStateRepository(
+    initialState: SyncProcessState = SyncProcessState.Idle,
+    initialLastSyncTimestamp: Long = 0L,
+) : UserDataSyncStateRepository {
+    private val state = MutableStateFlow(initialState)
+
+    val stateUpdates = mutableListOf<SyncProcessState>()
+    val savedTimestamps = mutableListOf<Long>()
+
+    var lastSyncTimestamp: Long = initialLastSyncTimestamp
+
+    override val userDataSyncState: StateFlow<SyncProcessState> = state
+
+    override fun updateUserDataSyncState(state: SyncProcessState) {
+        stateUpdates += state
+        this.state.value = state
+    }
+
+    override suspend fun getLastSyncTimestamp(): Long = lastSyncTimestamp
+
+    override suspend fun setLastSyncTimestamp(timestamp: Long) {
+        savedTimestamps += timestamp
+        lastSyncTimestamp = timestamp
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeUserProfileRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeUserProfileRepository.kt
@@ -1,0 +1,43 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.profile.model.UserProfile
+import kr.co.domain.feature.profile.repository.UserProfileRepository
+import kr.co.domain.testing.DomainFixtures
+
+data class UserProfilePhotoUpdate(
+    val uid: String,
+    val photoUrl: String,
+    val lastModifiedAt: Long,
+)
+
+class FakeUserProfileRepository(
+    initialProfile: AppResult<UserProfile> = Ok(DomainFixtures.userProfile()),
+) : UserProfileRepository {
+    val userProfileStream = MutableStateFlow(initialProfile)
+    val updatedProfiles = mutableListOf<UserProfile>()
+    val profilePhotoUpdates = mutableListOf<UserProfilePhotoUpdate>()
+
+    var updateUserProfileResult: AppResult<Unit> = Ok(Unit)
+    var updateUserProfilePhotoResult: AppResult<String> = Ok("photo-url-test")
+
+    override suspend fun getUserProfileStream(): Flow<AppResult<UserProfile>> = userProfileStream
+
+    override suspend fun updateUserProfile(profile: UserProfile): AppResult<Unit> {
+        updatedProfiles += profile
+        userProfileStream.value = Ok(profile)
+        return updateUserProfileResult
+    }
+
+    override suspend fun updateUserProfilePhoto(
+        uid: String,
+        photoUrl: String,
+        lastModifiedAt: Long,
+    ): AppResult<String> {
+        profilePhotoUpdates += UserProfilePhotoUpdate(uid, photoUrl, lastModifiedAt)
+        return updateUserProfilePhotoResult
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeUserSettingsRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeUserSettingsRepository.kt
@@ -1,0 +1,64 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kr.co.core.common.model.AppTheme
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.setting.model.UserSettings
+import kr.co.domain.feature.setting.repository.UserSettingsRepository
+import kr.co.domain.testing.DomainFixtures
+
+data class AppThemeUpdate(
+    val uid: String,
+    val appTheme: AppTheme,
+    val lastModifiedAt: Long,
+)
+
+data class DiarySyncEnabledUpdate(
+    val uid: String,
+    val enabled: Boolean,
+    val lastModifiedAt: Long,
+)
+
+class FakeUserSettingsRepository(
+    initialSettings: AppResult<UserSettings> = Ok(DomainFixtures.userSettings()),
+    initialAppTheme: AppTheme = AppTheme.SYSTEM,
+    initialDiarySyncEnabled: Boolean = false,
+) : UserSettingsRepository {
+    val userSettingsStream = MutableStateFlow(initialSettings)
+    val appThemeStream = MutableStateFlow(initialAppTheme)
+    val diarySyncEnabledStream = MutableStateFlow(initialDiarySyncEnabled)
+
+    val appThemeUpdates = mutableListOf<AppThemeUpdate>()
+    val diarySyncEnabledUpdates = mutableListOf<DiarySyncEnabledUpdate>()
+
+    var updateAppThemeResult: AppResult<Unit> = Ok(Unit)
+    var updateDiarySyncEnabledResult: AppResult<Unit> = Ok(Unit)
+
+    override suspend fun getUserSettingsStream(): Flow<AppResult<UserSettings>> = userSettingsStream
+
+    override fun getAppThemeStream(): Flow<AppTheme> = appThemeStream
+
+    override suspend fun updateAppTheme(
+        uid: String,
+        appTheme: AppTheme,
+        lastModifiedAt: Long,
+    ): AppResult<Unit> {
+        appThemeUpdates += AppThemeUpdate(uid, appTheme, lastModifiedAt)
+        appThemeStream.value = appTheme
+        return updateAppThemeResult
+    }
+
+    override fun getDiarySyncEnabledStream(): Flow<Boolean> = diarySyncEnabledStream
+
+    override suspend fun updateDiarySyncEnabled(
+        uid: String,
+        enabled: Boolean,
+        lastModifiedAt: Long,
+    ): AppResult<Unit> {
+        diarySyncEnabledUpdates += DiarySyncEnabledUpdate(uid, enabled, lastModifiedAt)
+        diarySyncEnabledStream.value = enabled
+        return updateDiarySyncEnabledResult
+    }
+}

--- a/domain/src/test/java/kr/co/domain/testing/fake/FakeUserStorageRepository.kt
+++ b/domain/src/test/java/kr/co/domain/testing/fake/FakeUserStorageRepository.kt
@@ -1,0 +1,16 @@
+package kr.co.domain.testing.fake
+
+import com.github.michaelbull.result.Ok
+import kr.co.core.common.result.AppResult
+import kr.co.domain.feature.user.repository.UserStorageRepository
+
+class FakeUserStorageRepository(
+    var deleteUserStorageResult: AppResult<Unit> = Ok(Unit),
+) : UserStorageRepository {
+    val deletedUids = mutableListOf<String>()
+
+    override suspend fun deleteUserStorage(uid: String): AppResult<Unit> {
+        deletedUids += uid
+        return deleteUserStorageResult
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,9 @@ hilt = "2.59.2"
 hiltNavigationCompose = "1.2.0"
 javaxInject = "1"
 coroutines = "1.8.0"
+junitJupiter = "5.10.2"
+junitPlatform = "1.10.2"
+mockk = "1.13.12"
 ksp = "2.3.2"
 kotlin = "2.3.10"
 coreKtx = "1.15.0"
@@ -57,10 +60,16 @@ androidx-paging-common = { module = "androidx.paging:paging-common", version.ref
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable", version.ref = "immutable" }
 javax-inject = { module = "javax.inject:javax.inject", version.ref = "javaxInject" }
+
+# unit test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 
 #firebase-bom
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }


### PR DESCRIPTION
## related issue
- closes: #73 

## why
- domain 모듈의 핵심 비즈니스 로직의 정확성, 안정성을 확보하기 위해 테스트 코드를 작성합니다.

## what
- TESTING.md: domain 모듈 테스트 가이드 문서 추가
- Unit Test Code 추가

## impact
- domain 모듈 및 관련 문서