### PR TITLE
build: 일부 build.gradle 파일에서 의존성 중복 선언 경고 처리

### DIFF
--- a/build-logic/src/main/kotlin/kr/co/minary/buildlogic/MinaryAndroidTestingConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/kr/co/minary/buildlogic/MinaryAndroidTestingConventionPlugin.kt
@@ -8,7 +8,7 @@ import org.gradle.kotlin.dsl.withType
 
 class MinaryAndroidTestingConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
-        configureUnitTestDependenciesOnce()
+        configureTestingDependenciesWhenPluginsAreReady()
 
         tasks.withType<Test>().configureEach {
             useJUnitPlatform()
@@ -20,20 +20,41 @@ class MinaryAndroidTestingConventionPlugin : Plugin<Project> {
     }
 }
 
-private fun Project.configureUnitTestDependenciesOnce() {
-    var configured = false
-
-    fun configure() {
-        if (configured) return
-        configured = true
-        dependencies {
-            testImplementation(libs.findLibrary("junit-jupiter").get())
-            testRuntimeOnly(libs.findLibrary("junit-platform-launcher").get())
-        }
+private fun Project.configureTestingDependenciesWhenPluginsAreReady() {
+    pluginManager.withPlugin("java") { configureUnitTestDependenciesOnce() }
+    pluginManager.withPlugin("java-library") { configureUnitTestDependenciesOnce() }
+    pluginManager.withPlugin("com.android.library") {
+        configureUnitTestDependenciesOnce()
+        configureAndroidTestingDependenciesOnce()
     }
+    pluginManager.withPlugin("com.android.application") {
+        configureUnitTestDependenciesOnce()
+        configureAndroidTestingDependenciesOnce()
+    }
+}
 
-    pluginManager.withPlugin("java") { configure() }
-    pluginManager.withPlugin("java-library") { configure() }
-    pluginManager.withPlugin("com.android.library") { configure() }
-    pluginManager.withPlugin("com.android.application") { configure() }
+private fun Project.configureUnitTestDependenciesOnce() {
+    if (extensions.extraProperties.has("minary.unitTestDependenciesConfigured")) return
+
+    extensions.extraProperties.set("minary.unitTestDependenciesConfigured", true)
+    dependencies {
+        testImplementation(libs.findLibrary("junit-jupiter").get())
+        testImplementation(libs.findLibrary("kotlinx-coroutines-test").get())
+        testImplementation(libs.findLibrary("mockk").get())
+        testRuntimeOnly(libs.findLibrary("junit-platform-launcher").get())
+    }
+}
+
+private fun Project.configureAndroidTestingDependenciesOnce() {
+    if (extensions.extraProperties.has("minary.androidTestDependenciesConfigured")) return
+
+    extensions.extraProperties.set("minary.androidTestDependenciesConfigured", true)
+    configureAndroidTestDependencies()
+}
+
+private fun Project.configureAndroidTestDependencies() {
+    dependencies {
+        "androidTestImplementation"(libs.findLibrary("kotlinx-coroutines-test").get())
+        "androidTestImplementation"(libs.findLibrary("mockk-android").get())
+    }
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -5,7 +5,4 @@ plugins {
 
 dependencies {
     api(libs.kotlin.result)
-
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -16,15 +16,10 @@ dependencies {
     implementation(libs.firebase.auth.ktx)
     implementation(libs.hilt.android)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.room.testing)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
 }

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -35,14 +35,9 @@ dependencies {
     api(libs.androidx.datastore.preferences)
     api(libs.protobuf.kotlin.lite)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
 }

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -11,9 +11,6 @@ android {
 dependencies {
     implementation(libs.kotlinx.coroutines.android)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)

--- a/core/firebase/build.gradle.kts
+++ b/core/firebase/build.gradle.kts
@@ -15,14 +15,9 @@ dependencies {
     implementation(libs.firebase.config)
     implementation(libs.firebase.storage.ktx)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
 }

--- a/core/storage/build.gradle.kts
+++ b/core/storage/build.gradle.kts
@@ -12,14 +12,9 @@ dependencies {
     implementation(libs.firebase.auth.ktx)
     implementation(libs.hilt.android)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.espresso.core)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
 }

--- a/core/ui/common/build.gradle.kts
+++ b/core/ui/common/build.gradle.kts
@@ -25,9 +25,6 @@ dependencies {
     implementation(libs.kotlin.parcelize.runtime)
     implementation(libs.kotlin.result)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
@@ -35,7 +32,5 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/core/ui/design/build.gradle.kts
+++ b/core/ui/design/build.gradle.kts
@@ -19,9 +19,6 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
 
-    testImplementation(libs.kotlinx.coroutines.test)
-    testImplementation(libs.mockk)
-
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.runner)
@@ -29,7 +26,5 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.ui.test.junit4)
-    androidTestImplementation(libs.kotlinx.coroutines.test)
-    androidTestImplementation(libs.mockk.android)
     debugImplementation(libs.androidx.ui.test.manifest)
 }


### PR DESCRIPTION
일부 build.gradle 파일에서 의존성 중복 선언으로 인한 경고가 발생하여 처리