### PR TITLE
test: Orbit ViewModel 테스트 정리 보강

### DIFF
--- a/presentation/src/test/java/kr/co/presentation/feature/home/screen/home/HomeViewModelTest.kt
+++ b/presentation/src/test/java/kr/co/presentation/feature/home/screen/home/HomeViewModelTest.kt
@@ -80,10 +80,15 @@ class HomeViewModelTest : BaseViewModelTest() {
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        initDiarySyncState.value = SyncProcessState.InProgress.Determinate(0.5f)
+        val expectedState = SyncProcessState.InProgress.Determinate(0.5f)
+        initDiarySyncState.value = expectedState
         advanceUntilIdle()
 
-        assertEquals(SyncProcessState.InProgress.Determinate(0.5f), viewModel.stateFlow().value.initDiarySyncProcessState)
+        assertEquals(
+            expectedState,
+            viewModel.awaitState { it.initDiarySyncProcessState == expectedState }
+                .initDiarySyncProcessState
+        )
     }
 
     @Test

--- a/presentation/src/test/java/kr/co/presentation/feature/search/screen/search/SearchViewModelTest.kt
+++ b/presentation/src/test/java/kr/co/presentation/feature/search/screen/search/SearchViewModelTest.kt
@@ -8,7 +8,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.advanceUntilIdle
 import kr.co.domain.feature.diary.model.Diary
 import kr.co.domain.feature.diary.usecase.GetPagedDiariesUseCase
 import kr.co.domain.feature.search.usecase.AddRecentSearchUseCase
@@ -85,9 +84,9 @@ class SearchViewModelTest : BaseViewModelTest() {
 
         viewModel.sideEffectFlow().test {
             viewModel.handleAction(SearchAction.DiaryClicked(PresentationFixtures.searchDiaryUiModel()))
-            advanceUntilIdle()
 
             assertEquals(SearchSideEffect.DiaryClicked(PresentationFixtures.DATE), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
     }
 

--- a/presentation/src/test/java/kr/co/presentation/testing/BaseViewModelTest.kt
+++ b/presentation/src/test/java/kr/co/presentation/testing/BaseViewModelTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -31,14 +32,20 @@ abstract class BaseViewModelTest {
 
     @AfterEach
     fun tearDownCoroutine() {
-        trackedContainers.forEach { it.container.cancel() }
-        trackedContainers.clear()
+        cancelTrackedContainers()
         Dispatchers.resetMain()
         clearAllMocks()
     }
 
     protected fun runPresentationTest(block: suspend TestScope.() -> Unit) =
-        runTest(testDispatcher) { block() }
+        runTest(testDispatcher) {
+            try {
+                block()
+            } finally {
+                cancelTrackedContainers()
+                advanceUntilIdle()
+            }
+        }
 
     protected fun <STATE : Any, SIDE_EFFECT : Any> ContainerHost<STATE, SIDE_EFFECT>.stateFlow(): StateFlow<STATE> =
         container.stateFlow
@@ -83,6 +90,11 @@ abstract class BaseViewModelTest {
         val item = awaitItem()
         return item as? SIDE_EFFECT
             ?: error("Expected ${SIDE_EFFECT::class.simpleName}, but was ${item::class.simpleName}.")
+    }
+
+    private fun cancelTrackedContainers() {
+        trackedContainers.forEach { it.container.cancel() }
+        trackedContainers.clear()
     }
 
     private companion object {


### PR DESCRIPTION
## related issue
- closes: #89

## why
- develop push CI에서 SearchViewModelTest가 이전 coroutine 예외를 감지해 실패함

## what
- runTest 종료 전에 추적 중인 Orbit container를 취소하고 테스트 스케줄러를 비움
- SearchViewModel side effect 테스트의 Turbine 이벤트 소비와 정리를 명시화

## impact
- presentation ViewModel unit test
- Android Fast Checks