### PR TITLE
ci: 수동 Android workflow 실행 환경 보강

### DIFF
--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -87,7 +87,7 @@ jobs:
           profile: pixel_6
           disable-animations: true
           script: |
-            set -euo pipefail
+            set -eu
             ./gradlew :core:database:connectedDebugAndroidTest :core:datastore:connectedDebugAndroidTest :core:firebase:connectedDebugAndroidTest :core:storage:connectedDebugAndroidTest :core:ui:common:connectedDebugAndroidTest :core:ui:design:connectedDebugAndroidTest
             ./gradlew :data:connectedDebugAndroidTest
             ./gradlew :presentation:connectedDebugAndroidTest

--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Install Android platform
         run: sdkmanager "platforms;android-36"
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Create CI Android local config
         run: |
           cat > local.properties <<'EOF'

--- a/.github/workflows/firebase-emulator.yml
+++ b/.github/workflows/firebase-emulator.yml
@@ -35,6 +35,12 @@ jobs:
       - name: Install Android platform
         run: sdkmanager "platforms;android-36"
 
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
@@ -54,6 +60,12 @@ jobs:
       - name: Build functions
         run: npm --prefix firebase-server/functions run build
 
+      - name: Set up JDK for Firebase emulators
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
       - name: Start Firebase Emulator Suite
         working-directory: firebase-server
         run: |
@@ -63,8 +75,18 @@ jobs:
       - name: Wait for Firebase emulators
         run: |
           for port in 9099 8080 5001 9199 8085; do
-            timeout 180 bash -c "until echo > /dev/tcp/127.0.0.1/${port}; do sleep 2; done" 2>/dev/null
+            echo "Waiting for Firebase emulator port ${port}"
+            timeout 180 bash -c "until echo > /dev/tcp/127.0.0.1/${port}; do sleep 2; done" 2>/dev/null || {
+              tail -200 "$GITHUB_WORKSPACE/firebase-emulator.log"
+              exit 1
+            }
           done
+
+      - name: Restore JDK for Android Gradle
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
 
       - name: Run Firebase integration tests on AVD
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/firebase-emulator.yml
+++ b/.github/workflows/firebase-emulator.yml
@@ -97,7 +97,7 @@ jobs:
           profile: pixel_6
           disable-animations: true
           script: |
-            set -euo pipefail
+            set -eu
             ./gradlew :data:connectedDebugAndroidTest \
               -Pandroid.testInstrumentationRunnerArguments.class=kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest \
               -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true \

--- a/presentation/src/test/java/kr/co/presentation/testing/BaseViewModelTest.kt
+++ b/presentation/src/test/java/kr/co/presentation/testing/BaseViewModelTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -32,7 +33,9 @@ abstract class BaseViewModelTest {
 
     @AfterEach
     fun tearDownCoroutine() {
-        cancelTrackedContainers()
+        runBlocking {
+            cancelTrackedContainersAndJoin()
+        }
         Dispatchers.resetMain()
         clearAllMocks()
     }
@@ -42,7 +45,7 @@ abstract class BaseViewModelTest {
             try {
                 block()
             } finally {
-                cancelTrackedContainers()
+                cancelTrackedContainersAndJoin()
                 advanceUntilIdle()
             }
         }
@@ -92,9 +95,11 @@ abstract class BaseViewModelTest {
             ?: error("Expected ${SIDE_EFFECT::class.simpleName}, but was ${item::class.simpleName}.")
     }
 
-    private fun cancelTrackedContainers() {
-        trackedContainers.forEach { it.container.cancel() }
+    private suspend fun cancelTrackedContainersAndJoin() {
+        val containers = trackedContainers.toList()
         trackedContainers.clear()
+        containers.forEach { it.container.cancel() }
+        containers.forEach { it.container.joinIntents() }
     }
 
     private companion object {


### PR DESCRIPTION
## related issue
- closes: #91
- closes: #93

## why
- Android Instrumented Tests와 Firebase Emulator Integration 수동 workflow가 GitHub Actions 환경에서 정상 실행되지 않았습니다.
- 첫 실패는 KVM 미설정과 Firebase Emulator의 Java 21 요구사항이었고, 이후 재실행에서는 emulator runner script가 /usr/bin/sh에서 Bash 전용 pipefail 옵션을 사용해 중단됐습니다.
- PR 자동 검증 중 Android Fast Checks에서 Orbit ViewModel 테스트의 미정리 intent가 다음 테스트에 영향을 주는 문제가 추가로 확인됐습니다.

## what
- Android emulator 실행 전 KVM 권한 설정을 추가했습니다.
- Firebase Emulator Suite 실행 구간에 JDK 21을 사용하고, Android Gradle 실행 전 JDK 17로 복구하도록 구성했습니다.
- Firebase emulator 포트 대기 실패 시 로그를 출력하도록 보강했습니다.
- emulator runner script를 POSIX sh 호환 옵션인 set -eu로 수정했습니다.
- BaseViewModelTest에서 tracked Orbit container를 cancel한 뒤 joinIntents까지 기다리도록 정리 로직을 보강했습니다.

## impact
- .github/workflows/android-instrumented.yml
- .github/workflows/firebase-emulator.yml
- presentation/src/test/java/kr/co/presentation/testing/BaseViewModelTest.kt
- Android 계측 테스트 수동 workflow
- Firebase Emulator 통합 테스트 수동 workflow
- presentation ViewModel JVM 테스트

## screenshots
<!-- UI 변경 없음 -->