### PR TITLE
ci: 수동 workflow 검증 안정화

### DIFF
--- a/.github/workflows/firebase-emulator.yml
+++ b/.github/workflows/firebase-emulator.yml
@@ -41,6 +41,43 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
+      - name: Create CI Android local config
+        run: |
+          cat > local.properties <<'EOF'
+          GEMINI_API_KEY=ci-gemini-api-key
+          EOF
+          cat > app/google-services.json <<'EOF'
+          {
+            "project_info": {
+              "project_number": "000000000000",
+              "project_id": "minary-ci",
+              "storage_bucket": "minary-ci.appspot.com"
+            },
+            "client": [
+              {
+                "client_info": {
+                  "mobilesdk_app_id": "1:000000000000:android:0000000000000000000000",
+                  "android_client_info": {
+                    "package_name": "kr.co.minary"
+                  }
+                },
+                "oauth_client": [],
+                "api_key": [
+                  {
+                    "current_key": "ci-api-key"
+                  }
+                ],
+                "services": {
+                  "appinvite_service": {
+                    "other_platform_oauth_client": []
+                  }
+                }
+              }
+            ],
+            "configuration_version": "1"
+          }
+          EOF
+
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/core/database/src/androidTest/java/kr/co/core/database/dao/DiaryDaoInstrumentedTest.kt
+++ b/core/database/src/androidTest/java/kr/co/core/database/dao/DiaryDaoInstrumentedTest.kt
@@ -2,8 +2,8 @@ package kr.co.core.database.dao
 
 import androidx.room.Room
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kr.co.core.common.model.Emotion
 import kr.co.core.common.state.DiarySyncStatus
 import kr.co.core.database.database.UserDatabase
@@ -69,15 +69,16 @@ class DiaryDaoInstrumentedTest : BaseInstrumentationTest() {
     @Test
     fun diaryFlow_emitsWhenRowsChange() {
         runCoreAndroidTest {
-            val emissions = async {
-                dao.getAllDiariesWithRelationsFlow().take(2).toList()
+            val updatedEmission = async {
+                dao.getAllDiariesWithRelationsFlow()
+                    .filter { it.isNotEmpty() }
+                    .first()
             }
 
             dao.insertDiaryWithRelations(DatabaseFixtures.relation())
 
-            val actual = emissions.await()
-            assertEquals(emptyList<Any>(), actual[0])
-            assertEquals(1, actual[1].size)
+            val actual = updatedEmission.await()
+            assertEquals(1, actual.size)
         }
     }
 


### PR DESCRIPTION
## related issue
- closes: #94
- closes: #95

## why
- Firebase Emulator Integration 수동 workflow가 CI 환경에서 local.properties 누락으로 Gradle 설정 단계에서 실패했습니다.
- Android Instrumented Tests 수동 workflow는 :core:database 계측 테스트에서 Room Flow의 첫 emission을 빈 리스트로 고정 기대해 실패했습니다.

## what
- Firebase Emulator Integration workflow에 CI용 local.properties와 app/google-services.json 생성 단계를 추가했습니다.
- DiaryDao Flow 계측 테스트가 빈 초기 emission에 의존하지 않고 insert 이후 비어 있지 않은 emission을 검증하도록 변경했습니다.

## impact
- .github/workflows/firebase-emulator.yml
- core/database/src/androidTest/java/kr/co/core/database/dao/DiaryDaoInstrumentedTest.kt
- Firebase Emulator Integration 수동 workflow
- Android Instrumented Tests 수동 workflow