### PR TITLE
ci: 수동 workflow 재현성 개선

### DIFF
--- a/.github/workflows/android-fast.yml
+++ b/.github/workflows/android-fast.yml
@@ -11,6 +11,7 @@ on:
       - "build-logic/**"
       - "gradle/**"
       - "firebase-server/**"
+      - "scripts/**"
       - ".github/workflows/**"
       - "**/AGENTS.md"
       - "**/TESTING.md"
@@ -31,6 +32,7 @@ on:
       - "build-logic/**"
       - "gradle/**"
       - "firebase-server/**"
+      - "scripts/**"
       - ".github/workflows/**"
       - "**/AGENTS.md"
       - "**/TESTING.md"
@@ -264,8 +266,8 @@ jobs:
       - name: Check Android architecture and logging boundaries
         run: |
           ! rg "kr\\.co\\.data|com\\.google\\.firebase|kr\\.co\\.minary" presentation/src/main/java
-          ! rg "android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" app/src/main/java data/src/main/java presentation/src/main/java domain/src/main/java core/*/src/main/java -g "*.kt"
-          ! rg "Timber\\." data/src/main/java presentation/src/main/java domain/src/main/java core/*/src/main/java -g "*.kt"
+          ! rg "android\\.util\\.Log|\\bLog\\.|printStackTrace\\(|println\\(" app/src/main/java data/src/main/java presentation/src/main/java domain/src/main/java core/common/src/main/java core/database/src/main/java core/datastore/src/main/java core/di/src/main/java core/firebase/src/main/java core/storage/src/main/java core/ui/common/src/main/java core/ui/design/src/main/java -g "*.kt"
+          ! rg "Timber\\." data/src/main/java presentation/src/main/java domain/src/main/java core/common/src/main/java core/database/src/main/java core/datastore/src/main/java core/di/src/main/java core/firebase/src/main/java core/storage/src/main/java core/ui/common/src/main/java core/ui/design/src/main/java -g "*.kt"
 
       - name: Check firebase-server secret and debug logging boundaries
         run: |

--- a/.github/workflows/android-instrumented.yml
+++ b/.github/workflows/android-instrumented.yml
@@ -12,9 +12,41 @@ concurrency:
 
 jobs:
   android-instrumented:
-    name: Android emulator connected tests
+    name: ${{ matrix.test-name }}
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          - test-name: core-database
+            module-path: core/database
+            gradle-command: ./gradlew :core:database:connectedDebugAndroidTest
+          - test-name: core-datastore
+            module-path: core/datastore
+            gradle-command: ./gradlew :core:datastore:connectedDebugAndroidTest
+          - test-name: core-firebase
+            module-path: core/firebase
+            gradle-command: ./gradlew :core:firebase:connectedDebugAndroidTest
+          - test-name: core-storage
+            module-path: core/storage
+            gradle-command: ./gradlew :core:storage:connectedDebugAndroidTest
+          - test-name: core-ui-common
+            module-path: core/ui/common
+            gradle-command: ./gradlew :core:ui:common:connectedDebugAndroidTest
+          - test-name: core-ui-design
+            module-path: core/ui/design
+            gradle-command: ./gradlew :core:ui:design:connectedDebugAndroidTest
+          - test-name: data
+            module-path: data
+            gradle-command: ./gradlew :data:connectedDebugAndroidTest
+          - test-name: presentation
+            module-path: presentation
+            gradle-command: ./gradlew :presentation:connectedDebugAndroidTest
+          - test-name: app-large
+            module-path: app
+            gradle-command: ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=androidx.test.filters.LargeTest
 
     steps:
       - name: Checkout
@@ -88,16 +120,13 @@ jobs:
           disable-animations: true
           script: |
             set -eu
-            ./gradlew :core:database:connectedDebugAndroidTest :core:datastore:connectedDebugAndroidTest :core:firebase:connectedDebugAndroidTest :core:storage:connectedDebugAndroidTest :core:ui:common:connectedDebugAndroidTest :core:ui:design:connectedDebugAndroidTest
-            ./gradlew :data:connectedDebugAndroidTest
-            ./gradlew :presentation:connectedDebugAndroidTest
-            ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.annotation=androidx.test.filters.LargeTest
+            ${{ matrix.gradle-command }}
 
       - name: Upload connected test reports
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: android-instrumented-reports
+          name: android-instrumented-${{ matrix.test-name }}-reports
           path: |
-            **/build/reports/androidTests/
-            **/build/outputs/androidTest-results/
+            ${{ matrix.module-path }}/build/reports/androidTests/
+            ${{ matrix.module-path }}/build/outputs/androidTest-results/

--- a/.github/workflows/firebase-emulator.yml
+++ b/.github/workflows/firebase-emulator.yml
@@ -135,10 +135,8 @@ jobs:
           disable-animations: true
           script: |
             set -eu
-            ./gradlew :data:connectedDebugAndroidTest \
-              -Pandroid.testInstrumentationRunnerArguments.class=kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest \
-              -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true \
-              -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorHost=10.0.2.2
+            FIREBASE_EMULATOR_TEST_CLASSES="kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest"
+            ./gradlew :data:connectedDebugAndroidTest "-Pandroid.testInstrumentationRunnerArguments.class=${FIREBASE_EMULATOR_TEST_CLASSES}" -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorHost=10.0.2.2
 
       - name: Stop Firebase Emulator Suite
         if: always()

--- a/core/TESTING.md
+++ b/core/TESTING.md
@@ -71,3 +71,20 @@ core/
 ```
 
 Firebase emulator smoke를 실제 실행하려면 `firebase-server`에서 Emulator Suite를 먼저 실행한다. Android emulator에서는 host `10.0.2.2`와 `firebase-server/firebase.json`의 포트를 사용한다.
+
+## Local CI Reproduction
+
+GitHub Actions의 `Android Instrumented Tests` 실패를 로컬에서 재현할 때는 Android Studio AVD 또는 실제 디바이스를 먼저 실행한 뒤 repository root에서 아래 script를 실행한다.
+
+```bash
+./scripts/ci/run-android-instrumented-local.sh
+```
+
+특정 실패 테스트만 빠르게 확인할 때는 class filter를 사용한다.
+
+```bash
+./gradlew :core:ui:design:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=kr.co.core.ui.design.theme.MinaryThemeInstrumentedTest
+```
+
+AVD는 GitHub Actions의 Android emulator와 가장 가까운 재현 환경이다. 실제 디바이스는 제조사/OS 설정 차이가 있으므로, CI 실패 재현은 가능하면 AVD에서 먼저 확인한다.

--- a/core/ui/design/src/androidTest/java/kr/co/core/ui/design/theme/MinaryThemeInstrumentedTest.kt
+++ b/core/ui/design/src/androidTest/java/kr/co/core/ui/design/theme/MinaryThemeInstrumentedTest.kt
@@ -16,25 +16,27 @@ class MinaryThemeInstrumentedTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun rendersContentWithLightAndDarkTheme() {
-        composeRule.setContent {
-            MinaryTheme(appTheme = AppTheme.LIGHT) {
-                Text(
-                    text = MaterialTheme.colorScheme.primary.toString(),
-                    modifier = Modifier.testTag("theme-content-test"),
-                )
-            }
-        }
-        composeRule.onNodeWithTag("theme-content-test").assertExists()
+    fun rendersContentWithLightTheme() {
+        renderTheme(AppTheme.LIGHT)
 
+        composeRule.onNodeWithTag("theme-content-test").assertExists()
+    }
+
+    @Test
+    fun rendersContentWithDarkTheme() {
+        renderTheme(AppTheme.DARK)
+
+        composeRule.onNodeWithTag("theme-content-test").assertExists()
+    }
+
+    private fun renderTheme(appTheme: AppTheme) {
         composeRule.setContent {
-            MinaryTheme(appTheme = AppTheme.DARK) {
+            MinaryTheme(appTheme = appTheme) {
                 Text(
                     text = MaterialTheme.colorScheme.primary.toString(),
                     modifier = Modifier.testTag("theme-content-test"),
                 )
             }
         }
-        composeRule.onNodeWithTag("theme-content-test").assertExists()
     }
 }

--- a/firebase-server/TESTING.md
+++ b/firebase-server/TESTING.md
@@ -50,7 +50,7 @@ Android `:data` Firebase Emulator integration test와 함께 사용할 때는 �
 
 ```bash
 cd firebase-server
-firebase emulators:start --only auth,firestore,functions,storage,pubsub
+firebase emulators:start --only auth,firestore,functions,storage,pubsub --project minary-2c818
 ```
 
 `functions/package.json`의 `serve` 스크립트는 현재 functions emulator만 실행한다.
@@ -69,9 +69,7 @@ Android Studio AVD에서는 Android가 host machine의 emulator에 접근할 때
 아래 Gradle 명령은 repository root에서 실행한다.
 
 ```bash
-./gradlew :data:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest \
-  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true
+./scripts/ci/run-firebase-emulator-local.sh
 ```
 
 실제 디바이스에서는 host machine port를 `adb reverse`로 연결하고 host를 `127.0.0.1`로 고정한다.
@@ -81,15 +79,21 @@ adb reverse tcp:9099 tcp:9099
 adb reverse tcp:8080 tcp:8080
 adb reverse tcp:5001 tcp:5001
 adb reverse tcp:9199 tcp:9199
-./gradlew :data:connectedDebugAndroidTest \
-  -Pandroid.testInstrumentationRunnerArguments.class=kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest \
-  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorHost=127.0.0.1 \
-  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true
+FIREBASE_EMULATOR_HOST=127.0.0.1 ./scripts/ci/run-firebase-emulator-local.sh
 ```
 
 위 명령은 Android `:data` 테스트가 실제 Firebase SDK를 통해 server rules/functions 계약을 검증하는 경로다.
 `firebaseEmulatorEnabled=true`를 넘기지 않으면 Android emulator integration test는 skip되어 일반 connected
 테스트 루프를 방해하지 않는다.
+
+script가 실제로 실행하는 Gradle 명령은 아래와 같다.
+
+```bash
+./gradlew :data:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.class=kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest \
+  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true \
+  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorHost=10.0.2.2
+```
 
 ## Rules 검증 기준
 
@@ -197,7 +201,7 @@ Functions 변경:
 cd firebase-server
 npm --prefix functions run lint
 npm --prefix functions run build
-firebase emulators:start --only auth,firestore,functions,storage,pubsub
+firebase emulators:start --only auth,firestore,functions,storage,pubsub --project minary-2c818
 ```
 
 경로 계약 변경:

--- a/scripts/ci/run-android-instrumented-local.sh
+++ b/scripts/ci/run-android-instrumented-local.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+./gradlew \
+  :core:database:connectedDebugAndroidTest \
+  :core:datastore:connectedDebugAndroidTest \
+  :core:firebase:connectedDebugAndroidTest \
+  :core:storage:connectedDebugAndroidTest \
+  :core:ui:common:connectedDebugAndroidTest \
+  :core:ui:design:connectedDebugAndroidTest
+
+./gradlew :data:connectedDebugAndroidTest
+./gradlew :presentation:connectedDebugAndroidTest
+./gradlew :app:connectedDebugAndroidTest \
+  -Pandroid.testInstrumentationRunnerArguments.annotation=androidx.test.filters.LargeTest

--- a/scripts/ci/run-firebase-emulator-local.sh
+++ b/scripts/ci/run-firebase-emulator-local.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+FIREBASE_EMULATOR_HOST="${FIREBASE_EMULATOR_HOST:-10.0.2.2}"
+FIREBASE_EMULATOR_TEST_CLASSES="kr.co.data.firebase.FirebaseEmulatorIntegrationSmokeTest,kr.co.data.feature.diary.sync.FirestoreDiarySyncManagerEmulatorTest,kr.co.data.feature.profile.sync.FirestoreUserProfileSyncManagerEmulatorTest,kr.co.data.feature.setting.sync.FirestoreUserSettingsSyncManagerEmulatorTest"
+
+./gradlew :data:connectedDebugAndroidTest \
+  "-Pandroid.testInstrumentationRunnerArguments.class=${FIREBASE_EMULATOR_TEST_CLASSES}" \
+  -Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorEnabled=true \
+  "-Pandroid.testInstrumentationRunnerArguments.firebaseEmulatorHost=${FIREBASE_EMULATOR_HOST}"


### PR DESCRIPTION
## related issue
- closes: #97

## why
- Android Instrumented Tests와 Firebase Emulator Integration이 CI에서 실패했을 때 로컬 재현 경로가 명확하지 않았다.
- 수동 계측 workflow가 한 job에서 순차 실행되어 첫 실패 이후의 모듈 실패를 한 번에 확인하기 어려웠다.

## what
- Compose theme 계측 테스트의 `setContent` 중복 호출을 light/dark 별도 테스트로 분리했다.
- Firebase Emulator workflow의 Gradle 명령을 줄바꿈 이스케이프 없이 실행하도록 정리했다.
- `scripts/ci/run-android-instrumented-local.sh`, `scripts/ci/run-firebase-emulator-local.sh`를 추가하고 TESTING 문서에 로컬 재현 절차를 고정했다.
- Android Instrumented workflow를 모듈별 matrix로 분리하고, `scripts/**` path trigger와 core/ui 로그 경계 검사를 보강했다.

## impact
- GitHub Actions: Android Fast Checks, Android Instrumented Tests, Firebase Emulator Integration
- :core:ui:design 계측 테스트
- firebase-server / :data emulator integration runbook