### PR TITLE
test: HomeViewModel 초기화 검증 안정화

### DIFF
--- a/presentation/src/test/java/kr/co/presentation/feature/home/screen/home/HomeViewModelTest.kt
+++ b/presentation/src/test/java/kr/co/presentation/feature/home/screen/home/HomeViewModelTest.kt
@@ -64,12 +64,12 @@ class HomeViewModelTest : BaseViewModelTest() {
             awaitItem()
             advanceUntilIdle()
 
-            coVerify { initUserStorage(PresentationFixtures.UID) }
-            coVerify { startUserDataSync(PresentationFixtures.UID) }
-            coVerify { startRealtimeUserProfileSync() }
-            coVerify { startRealtimeUserSettingsSync() }
-            coVerify { startDiarySync() }
-            coVerify { startRealtimeDiarySync() }
+            coVerify(timeout = 1_000) { initUserStorage(PresentationFixtures.UID) }
+            coVerify(timeout = 1_000) { startUserDataSync(PresentationFixtures.UID) }
+            coVerify(timeout = 1_000) { startRealtimeUserProfileSync() }
+            coVerify(timeout = 1_000) { startRealtimeUserSettingsSync() }
+            coVerify(timeout = 1_000) { startDiarySync() }
+            coVerify(timeout = 1_000) { startRealtimeDiarySync() }
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
## related issue
- see also: #99

## why
- PR #98 merge 후 develop 브랜치의 Android Fast Checks에서 `:presentation:testDebugUnitTest`가 실패했다.
- 실패 원인은 `HomeViewModelTest`가 Orbit 초기화 intent의 UseCase 호출을 기다리지 못한 타이밍 문제였다.

## what
- `init starts user and diary sync when current user exists` 테스트의 startup UseCase 호출 검증에 MockK `timeout`을 적용했다.
- `orbit-test` 도입은 별도 이슈 #99로 분리했다.

## impact
- :presentation:testDebugUnitTest
- HomeViewModelTest

## screenshots
<!-- UI 변경 없음 -->