### PR TITLE
docs: 테스트 운영 문서와 로컬 CI 스크립트 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@
 - 같은 원칙 안에서 화면, UseCase, Mapper, ViewModel이 단순 추가되는 경우 문서 갱신은 필수가 아니다.
 - Firestore/Storage 경로, sync 정책, App Check, budget 방어 로직 변경 시 Android와 `firebase-server`를 함께 검증한다.
 - 로컬 커밋은 `.gitmessage.txt` 템플릿을 따르고, GitHub Issue/PR 작성 시 `.github/` 하위 템플릿을 우선 참조한다.
+- 테스트 운영 기준은 루트 `TESTING.md`를 우선 참고하고, 모듈별 세부 기준은 각 모듈의 `TESTING.md`를 따른다.
 
 ## 권장 검증
 - 문서 배치 확인: `find . -name AGENTS.md -print | sort`

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,144 @@
+# Minary Testing Guide
+
+> 이 문서는 `:core`, `:domain`, `:data`, `:presentation`, `:app`, `firebase-server`를 포함한 전체 테스트 운영 방법을 정리한다.
+> 모듈별 세부 규칙은 각 모듈의 `TESTING.md`를 우선한다.
+
+## 목적
+
+- 로컬에서 테스트를 어떻게 재현하는지 한눈에 확인한다.
+- GitHub Actions가 어떤 검증을 자동/수동으로 수행하는지 이해한다.
+- 실패가 났을 때 로컬 재현과 CI 로그 확인 순서를 빠르게 잡는다.
+
+## 전체 문서 구조
+
+- [core/TESTING.md](./core/TESTING.md)
+- [domain/TESTING.md](./domain/TESTING.md)
+- [data/TESTING.md](./data/TESTING.md)
+- [presentation/TESTING.md](./presentation/TESTING.md)
+- [app/TESTING.md](./app/TESTING.md)
+- [firebase-server/TESTING.md](./firebase-server/TESTING.md)
+
+## 로컬 테스트 운영
+
+### 1. Android Studio Edit Configuration
+
+프로젝트는 GitHub Actions와 같은 흐름을 로컬에서도 재현할 수 있도록 Shell Script 기반 Run Configuration을 사용한다.
+
+권장 설정은 다음과 같다.
+
+- `Start Firebase Emulator Suite`
+  - `Script file`
+  - `Interpreter path`: `/bin/bash`
+  - `Execute in the terminal`: 해제
+- `CI - Android Fast Checks`
+  - `Script file`
+  - `Interpreter path`: `/bin/bash`
+  - `Execute in the terminal`: 해제
+- `CI - Android Instrumented Tests`
+  - `Script file`
+  - `Interpreter path`: `/bin/bash`
+  - `Execute in the terminal`: 해제
+- `CI - Firebase Emulator Integration`
+  - `Script file`
+  - `Interpreter path`: `/bin/bash`
+  - `Execute in the terminal`: 해제
+
+이 설정을 쓰는 이유는 프로젝트의 재현 스크립트가 `bash` 기준으로 작성되어 있기 때문이다.
+`zsh`로 실행하면 `BASH_SOURCE[0]` 같은 bash 전용 문법이 깨질 수 있다.
+
+### 2. 로컬 스크립트
+
+프로젝트 루트 기준으로 아래 스크립트를 실행한다.
+
+```bash
+./scripts/ci/run-android-fast-local.sh
+./scripts/ci/run-android-instrumented-local.sh
+./scripts/ci/start-firebase-emulator-suite-local.sh
+./scripts/ci/run-firebase-emulator-local.sh
+./scripts/ci/run-firebase-emulator-integration-local.sh
+```
+
+스크립트별 역할은 다음과 같다.
+
+- `run-android-fast-local.sh`
+  - JVM unit test
+  - Android test source compile
+  - app assemble
+  - firebase-server lint/build
+- `run-android-instrumented-local.sh`
+  - Android emulator 또는 실제 디바이스에서 계측 테스트 실행
+- `start-firebase-emulator-suite-local.sh`
+  - Firebase Emulator Suite만 수동 실행
+- `run-firebase-emulator-local.sh`
+  - Firebase Emulator를 전제로 Android `:data` 통합 테스트 실행
+- `run-firebase-emulator-integration-local.sh`
+  - functions lint/build
+  - emulator start
+  - emulator port wait
+  - Android integration test
+  - emulator 종료
+
+### 3. 로컬 재현 기준
+
+- 빠른 실패 확인은 `CI - Android Fast Checks`를 먼저 실행한다.
+- Android UI/계측 문제는 `CI - Android Instrumented Tests`를 사용한다.
+- Firebase rules/functions 계약 문제는 `CI - Firebase Emulator Integration`을 사용한다.
+- 실제 디바이스와 Android Studio AVD 둘 다 사용할 수 있지만, emulator 계약 문제는 AVD가 우선이다.
+
+## GitHub Actions 운영
+
+현재 프로젝트의 GitHub Actions는 다음 3개 workflow로 구성한다.
+
+- `android-fast.yml`
+- `android-instrumented.yml`
+- `firebase-emulator.yml`
+
+### `android-fast.yml`
+
+GitHub PR 생성, Merge에서 자동 실행되는 기본 검증이다.
+
+포함 내용:
+
+- build-logic check
+- JVM unit tests
+- Android test source compile
+- app assemble
+- firebase-server lint/build
+- 경계 검사
+
+### `android-instrumented.yml`
+
+Android emulator 기반 계측 테스트용이다.
+
+특징:
+
+- `workflow_dispatch`로 수동 실행한다.
+- 실제 디바이스 또는 Android Studio AVD와 같은 Android 런타임 검증에 사용한다.
+
+### `firebase-emulator.yml`
+
+Firebase Emulator Suite 통합 검증용이다.
+
+특징:
+
+- `workflow_dispatch`로 수동 실행한다.
+- Auth, Firestore, Functions, Storage 계약 검증에 사용한다.
+- production Firebase project를 대상으로 실행하지 않는다.
+
+## 어디에 무엇을 적을지
+
+- 프로젝트 공통 운영 규칙과 로컬 재현은 이 파일에 적는다.
+- `:core`, `:domain`, `:data`, `:presentation`, `:app`, `firebase-server`의 세부 시나리오는 각 모듈 `TESTING.md`에 둔다.
+- CI workflow 구조가 바뀌면 이 파일의 workflow 섹션과 `.github/workflows`를 함께 갱신한다.
+
+## 실패 시 확인 순서
+
+1. 로컬 스크립트로 같은 명령을 재현한다.
+2. Android Studio Run Configuration의 interpreter가 `/bin/bash`인지 확인한다.
+3. GitHub Actions 로그에서 실패한 job과 step을 확인한다.
+4. Firebase 관련 실패는 emulator 로그와 `firebase-server` 문서를 함께 본다.
+
+## 참고
+
+- `TESTING.md`는 구현 코드가 아니라 운영 문서다.
+- 테스트 자체의 상세 설계는 각 모듈 문서와 실제 test source를 우선한다.

--- a/core/TESTING.md
+++ b/core/TESTING.md
@@ -76,6 +76,14 @@ Firebase emulator smoke를 실제 실행하려면 `firebase-server`에서 Emulat
 
 GitHub Actions의 `Android Instrumented Tests` 실패를 로컬에서 재현할 때는 Android Studio AVD 또는 실제 디바이스를 먼저 실행한 뒤 repository root에서 아래 script를 실행한다.
 
+GitHub Actions의 `Android Fast Checks`와 같은 빠른 JVM/compile/build 검증은 아래 script로 실행한다.
+
+```bash
+./scripts/ci/run-android-fast-local.sh
+```
+
+`Android Instrumented Tests`는 Android Studio AVD 또는 실제 디바이스를 먼저 실행한 뒤 repository root에서 아래 script를 실행한다.
+
 ```bash
 ./scripts/ci/run-android-instrumented-local.sh
 ```

--- a/firebase-server/TESTING.md
+++ b/firebase-server/TESTING.md
@@ -49,8 +49,7 @@ npm --prefix functions run build
 Android `:data` Firebase Emulator integration test와 함께 사용할 때는 전체 관련 emulator를 실행한다.
 
 ```bash
-cd firebase-server
-firebase emulators:start --only auth,firestore,functions,storage,pubsub --project minary-2c818
+./scripts/ci/start-firebase-emulator-suite-local.sh
 ```
 
 `functions/package.json`의 `serve` 스크립트는 현재 functions emulator만 실행한다.
@@ -70,6 +69,12 @@ Android Studio AVD에서는 Android가 host machine의 emulator에 접근할 때
 
 ```bash
 ./scripts/ci/run-firebase-emulator-local.sh
+```
+
+Emulator Suite 시작, functions lint/build, Android integration test, emulator 종료까지 한 번에 실행하려면 아래 script를 사용한다.
+
+```bash
+./scripts/ci/run-firebase-emulator-integration-local.sh
 ```
 
 실제 디바이스에서는 host machine port를 `adb reverse`로 연결하고 host를 `127.0.0.1`로 고정한다.

--- a/scripts/ci/run-android-fast-local.sh
+++ b/scripts/ci/run-android-fast-local.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+./gradlew -p build-logic check
+
+./gradlew :core:common:test :core:di:test :domain:test
+
+./gradlew \
+  :core:database:testDebugUnitTest \
+  :core:datastore:testDebugUnitTest \
+  :core:firebase:testDebugUnitTest \
+  :core:storage:testDebugUnitTest \
+  :core:ui:common:testDebugUnitTest \
+  :core:ui:design:testDebugUnitTest
+
+./gradlew \
+  :data:testDebugUnitTest \
+  :presentation:testDebugUnitTest \
+  :app:testDebugUnitTest
+
+./gradlew \
+  :core:database:compileDebugAndroidTestKotlin \
+  :core:datastore:compileDebugAndroidTestKotlin \
+  :core:firebase:compileDebugAndroidTestKotlin \
+  :core:storage:compileDebugAndroidTestKotlin \
+  :core:ui:common:compileDebugAndroidTestKotlin \
+  :core:ui:design:compileDebugAndroidTestKotlin
+
+./gradlew \
+  :data:compileDebugAndroidTestKotlin \
+  :presentation:compileDebugAndroidTestKotlin \
+  :app:compileDebugAndroidTestKotlin
+
+./gradlew :app:assembleDebug
+
+npm --prefix firebase-server/functions ci
+npm --prefix firebase-server/functions run lint
+npm --prefix firebase-server/functions run build

--- a/scripts/ci/run-firebase-emulator-integration-local.sh
+++ b/scripts/ci/run-firebase-emulator-integration-local.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+FIREBASE_EMULATOR_HOST="${FIREBASE_EMULATOR_HOST:-10.0.2.2}"
+FIREBASE_EMULATOR_LOG="${ROOT_DIR}/firebase-emulator-local.log"
+FIREBASE_EMULATOR_PID=""
+
+cleanup() {
+  if [[ -n "${FIREBASE_EMULATOR_PID}" ]] && kill -0 "${FIREBASE_EMULATOR_PID}" 2>/dev/null; then
+    kill "${FIREBASE_EMULATOR_PID}" 2>/dev/null || true
+    wait "${FIREBASE_EMULATOR_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+npm --prefix firebase-server/functions ci
+npm --prefix firebase-server/functions run lint
+npm --prefix firebase-server/functions run build
+
+(
+  cd firebase-server
+  firebase emulators:start \
+    --only auth,firestore,functions,storage,pubsub \
+    --project minary-2c818
+) > "${FIREBASE_EMULATOR_LOG}" 2>&1 &
+FIREBASE_EMULATOR_PID="$!"
+
+for port in 9099 8080 5001 9199 8085; do
+  echo "Waiting for Firebase emulator port ${port}"
+  timeout 180 bash -c "until echo > /dev/tcp/127.0.0.1/${port}; do sleep 2; done" 2>/dev/null || {
+    tail -200 "${FIREBASE_EMULATOR_LOG}" || true
+    exit 1
+  }
+done
+
+FIREBASE_EMULATOR_HOST="${FIREBASE_EMULATOR_HOST}" \
+  "${ROOT_DIR}/scripts/ci/run-firebase-emulator-local.sh"

--- a/scripts/ci/start-firebase-emulator-suite-local.sh
+++ b/scripts/ci/start-firebase-emulator-suite-local.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}/firebase-server"
+
+firebase emulators:start \
+  --only auth,firestore,functions,storage,pubsub \
+  --project minary-2c818


### PR DESCRIPTION
## why
- 로컬에서 GitHub Actions와 동일한 검증 경로를 재현할 수 있어야 테스트 실패 원인을 빠르게 좁힐 수 있다.
- 모듈별 TESTING.md와 루트 운영 문서를 분리해, 전체 테스트 운영 기준을 한곳에서 확인할 수 있게 한다.

## what
- 루트 `TESTING.md`를 추가해 로컬 재현 방식과 GitHub Actions 운영 방식을 정리했다.
- 루트 `AGENTS.md`에 테스트 운영 문서 참조를 추가했다.
- `core/TESTING.md`와 `firebase-server/TESTING.md`에 로컬 재현 스크립트 기준을 보강했다.
- Android Fast Checks 및 Firebase Emulator 통합용 로컬 재현 스크립트를 추가했다.

## impact
- Android Studio Edit Configuration에서 CI와 같은 검증을 로컬에서 재현할 수 있다.
- GitHub Actions와 로컬 테스트 운영 기준이 문서로 연결되어 유지보수성이 좋아진다.